### PR TITLE
fix: Add stateless_http=True to FastMCP constructor

### DIFF
--- a/src/srclight/server.py
+++ b/src/srclight/server.py
@@ -160,6 +160,7 @@ mcp = FastMCP(
     instructions=_INSTRUCTIONS_TEMPLATE.format(
         dynamic_section="You have access to a code index with searchable symbols, call graphs, and git history.\n\n"
     ),
+    stateless_http=True,
 )
 
 # Global state — initialized on first tool call or via configure()


### PR DESCRIPTION
## Summary
- Adds `stateless_http=True` to the `FastMCP()` constructor in `server.py`
- Prevents `-32600 Session not found` errors when the MCP server restarts
- Each HTTP request is now independent — no session tracking needed

Closes #5

## Test plan
- [x] Server module imports successfully
- [x] 172 existing tests pass (10 pre-existing failures in `test_new_tools.py` unrelated)
- [ ] Manual: restart server, verify connected clients reconnect without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)