### PR TITLE
fix: community detection fails on 50k+ symbol repos (SQLite variable limit)

### DIFF
--- a/src/srclight/community.py
+++ b/src/srclight/community.py
@@ -22,6 +22,26 @@ from .db import Database
 logger = logging.getLogger("srclight.community")
 
 
+# SQLite caps bound parameters per statement (default 999). Batch large
+# `WHERE id IN (...)` lookups so community detection works on 50k+ symbol repos.
+_IN_CHUNK = 500
+
+
+def _chunked_in_select(conn, columns: str, table: str, ids, *, chunk: int = _IN_CHUNK):
+    """Run ``SELECT {columns} FROM {table} WHERE id IN (...)`` over ``ids`` in chunks.
+
+    ``columns`` and ``table`` are internal literal strings (not user input).
+    Yields matching rows. Avoids SQLite's bound-parameter limit on large repos.
+    """
+    id_list = list(ids)
+    for start in range(0, len(id_list), chunk):
+        batch = id_list[start:start + chunk]
+        placeholders = ",".join("?" * len(batch))
+        yield from conn.execute(
+            f"SELECT {columns} FROM {table} WHERE id IN ({placeholders})", batch,
+        )
+
+
 def detect_communities(db: Database) -> list[dict[str, Any]]:
     """Detect communities in the call graph using Louvain algorithm.
 
@@ -67,10 +87,8 @@ def detect_communities(db: Database) -> list[dict[str, Any]]:
 
     id_to_name = {}
     if all_ids:
-        placeholders = ",".join("?" * len(all_ids))
-        for row in db.conn.execute(
-            f"SELECT id, name, qualified_name, kind FROM symbols WHERE id IN ({placeholders})",
-            list(all_ids),
+        for row in _chunked_in_select(
+            db.conn, "id, name, qualified_name, kind", "symbols", all_ids
         ):
             id_to_name[row["id"]] = {
                 "id": row["id"],
@@ -229,11 +247,9 @@ def trace_execution_flows(
     if not edge_node_ids:
         return []
 
-    placeholders = ",".join("?" * len(edge_node_ids))
     id_to_info: dict[int, dict] = {}
-    for row in db.conn.execute(
-        f"SELECT id, name, kind, file_id FROM symbols WHERE id IN ({placeholders})",
-        list(edge_node_ids),
+    for row in _chunked_in_select(
+        db.conn, "id, name, kind, file_id", "symbols", edge_node_ids
     ):
         id_to_info[row["id"]] = {
             "name": row["name"], "kind": row["kind"], "file_id": row["file_id"],
@@ -258,10 +274,7 @@ def trace_execution_flows(
     file_ids = {info["file_id"] for info in id_to_info.values() if info.get("file_id")}
     test_file_ids: set[int] = set()
     if file_ids:
-        fp = ",".join("?" * len(file_ids))
-        for row in db.conn.execute(
-            f"SELECT id, path FROM files WHERE id IN ({fp})", list(file_ids)
-        ):
+        for row in _chunked_in_select(db.conn, "id, path", "files", file_ids):
             if "test" in row["path"].lower():
                 test_file_ids.add(row["id"])
 

--- a/src/srclight/db.py
+++ b/src/srclight/db.py
@@ -789,16 +789,24 @@ class Database:
     # --- Edges ---
 
     def delete_edges_for_symbols(self, symbol_ids: list[int]) -> None:
-        """Delete all edges where source or target is in the given symbol IDs."""
+        """Delete all edges where source or target is in the given symbol IDs.
+
+        Batched to stay under SQLite's bound-parameter limit (default 999) on
+        large reindexes. A chunked OR-delete across all batches removes exactly
+        the edges whose source OR target is anywhere in ``symbol_ids``.
+        """
         assert self.conn is not None
         if not symbol_ids:
             return
-        placeholders = ",".join("?" * len(symbol_ids))
-        self.conn.execute(
-            f"DELETE FROM symbol_edges WHERE source_id IN ({placeholders})"
-            f" OR target_id IN ({placeholders})",
-            symbol_ids + symbol_ids,
-        )
+        chunk = 500
+        for start in range(0, len(symbol_ids), chunk):
+            batch = symbol_ids[start:start + chunk]
+            placeholders = ",".join("?" * len(batch))
+            self.conn.execute(
+                f"DELETE FROM symbol_edges WHERE source_id IN ({placeholders})"
+                f" OR target_id IN ({placeholders})",
+                batch + batch,
+            )
 
     def all_symbol_names(self) -> dict[str, list[int]]:
         """Return a mapping of symbol name -> list of symbol IDs.
@@ -1272,6 +1280,8 @@ class Database:
                     (member["id"], c["id"]),
                 )
 
+        self.conn.commit()
+
     def get_communities(self) -> list[dict]:
         """Get all communities with stats."""
         assert self.conn is not None
@@ -1333,6 +1343,8 @@ class Database:
                        VALUES (?, ?, ?, ?)""",
                     (flow_id, step["order"], step["symbol_id"], step.get("community_id")),
                 )
+
+        self.conn.commit()
 
     def get_execution_flows(self, limit: int = 50) -> list[dict]:
         """Get top execution flows ordered by step count."""

--- a/tests/test_community.py
+++ b/tests/test_community.py
@@ -318,3 +318,34 @@ def test_store_and_retrieve_flows(db):
 
     login_flows = db.get_flows_for_symbol(syms["login"])
     assert len(login_flows) >= 1
+
+
+def test_detect_communities_large_graph_above_sql_variable_limit(db):
+    """Regression: >999 symbols must not hit SQLite's bound-parameter limit.
+
+    detect_communities builds ``WHERE id IN (?,?,...)`` over all community member
+    ids; without chunking this raised sqlite3.OperationalError "too many SQL
+    variables" on repos with 50k+ symbols. See community._chunked_in_select.
+    """
+    from srclight.community import detect_communities
+
+    f = db.upsert_file(FileRecord(
+        path="big.py", content_hash="z", mtime=1.0,
+        language="python", size=10, line_count=5,
+    ))
+    ids = [
+        db.insert_symbol(SymbolRecord(
+            file_id=f, kind="function", name=f"fn_{i}",
+            qualified_name=f"big.fn_{i}", start_line=1, end_line=2,
+            content="pass",
+        ), file_path="big.py")
+        for i in range(1100)  # well above SQLite's default 999-variable limit
+    ]
+    # Chain edges so the graph is connected and forms at least one community.
+    for a, b in zip(ids, ids[1:]):
+        db.insert_edge(EdgeRecord(source_id=a, target_id=b, edge_type="calls"))
+    db.commit()
+
+    communities = detect_communities(db)  # must not raise "too many SQL variables"
+    assert len(communities) >= 1
+    assert sum(c["symbol_count"] for c in communities) >= 1000


### PR DESCRIPTION
## Problem

`detect_communities()` and `trace_execution_flows()` build a single
`WHERE id IN (?,?,...)` over all community member symbol ids. On repos with
more than 999 symbols in the graph this exceeds SQLite's bound-parameter
limit and raises:

```
sqlite3.OperationalError: too many SQL variables
```

The indexer catches the exception in its community block and **silently skips
community detection**, so `communities` / `execution_flows` stay empty on any
large codebase. The same `IN (...)` pattern also affects
`Database.delete_edges_for_symbols` (hit during reindex), and
`store_communities` / `store_execution_flows` never call `commit()` (matters
for standalone recomputation).

## Fix

- **`community.py`**: add `_chunked_in_select()` that batches `WHERE id IN (...)`
  lookups in groups of 500; applied to the 3 unbounded lookups
  (`detect_communities`, `trace_execution_flows` symbols + files).
- **`db.py`**: chunk the OR-DELETE in `delete_edges_for_symbols`.
- **`db.py`**: add `commit()` to `store_communities` and `store_execution_flows`.
- **`tests/test_community.py`**: regression test with a 1100-symbol graph
  (>999) — previously raised, now passes.

## Verification

- `tests/test_community.py`: **14/14** (incl. new regression).
- Real reproducer — a 55,440-symbol / 907,709-edge repo:
  - `detect_communities` → 42 communities (9.3s)
  - `trace_execution_flows` → 50 flows (1.1s)
  - no SQLite error
