### PR TITLE
docs: note FTS keyword-AND semantics for search_symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Srclight exposes 42 MCP tools organized in seven tiers. The MCP server includes 
 | Tool | What it does |
 |------|-------------|
 | `codebase_map()` | Full project overview — call first every session |
-| `search_symbols(query)` | Search across symbol names, code, and docs |
+| `search_symbols(query)` | Keyword (FTS5) search across symbol names, code, and docs |
 | `get_symbol(name)` | Full source code + metadata for a symbol |
 | `get_signature(name)` | Just the signature (lightweight) |
 | `symbols_in_file(path)` | Table of contents for a file |
@@ -352,6 +352,10 @@ Srclight exposes 42 MCP tools organized in seven tiers. The MCP server includes 
 | `restart_server()` | Request server restart (SSE only) |
 
 In workspace mode, `search_symbols`, `get_symbol`, `codebase_map`, and `hybrid_search` accept an optional `project` filter. Graph/git/build/community tools require `project` in workspace mode.
+
+### Choosing a search tool
+
+`search_symbols` is keyword-exact (FTS5); `semantic_search` is embedding-based; `hybrid_search` fuses both via RRF. In FTS5, a **bare multi-word query is implicitly ANDed** — every token must match the same symbol, so a long keyword list can return zero and read as "not indexed." For keyword search, prefer a single distinctive symbol/term or a `"quoted phrase"`. When a keyword miss might just be different wording, reach for `hybrid_search`/`semantic_search` rather than concluding the symbol is absent. A zero result under a `project` filter means absent from *that project*, not the whole workspace — retry without `project` to search all repos.
 
 ## Deployment Guide
 

--- a/src/srclight/server.py
+++ b/src/srclight/server.py
@@ -32,8 +32,10 @@ _INSTRUCTIONS_TEMPLATE = """Welcome to Srclight — deep code indexing for AI ag
 
 ## Which Search Tool to Use
 - **`hybrid_search(query)`** — BEST for most queries. Combines keyword + semantic search via RRF fusion. Use for natural language ("find dictionary lookup code") or keywords.
-- **`search_symbols(query)`** — keyword-only search. Faster, good for exact symbol names or code fragments.
+- **`search_symbols(query)`** — keyword-only (FTS5) search. Faster, good for exact symbol names or code fragments. **Keyword semantics:** a bare multi-word query is implicitly ANDed — every token must match, so a long keyword list can return zero and read as "not indexed." Prefer a single distinctive symbol/term (or a `"quoted phrase"`); when a keyword miss might just be wording, route to `hybrid_search`/`semantic_search` for concept-level recall rather than concluding absence.
 - **`semantic_search(query)`** — embedding-only search. Good when you know the concept but not the terminology.
+
+A zero result under a `project` filter means "absent from that project," not "absent from the workspace" — retry without `project` to search all repos.
 
 ## The `project` Parameter
 In workspace mode (multi-repo), many tools accept an optional `project` parameter:
@@ -462,11 +464,20 @@ def search_symbols(
 ) -> str:
     """Search for code symbols (functions, classes, methods, structs, etc.).
 
-    Uses tiered search: symbol names → source code content → documentation.
-    In workspace mode, searches across all projects simultaneously.
+    Keyword-only (FTS5) search using tiered matching: symbol names →
+    source code content → documentation. In workspace mode, searches
+    across all projects simultaneously.
+
+    Keyword semantics: a bare multi-word query is implicitly ANDed —
+    every token must match the same symbol, so long keyword lists can
+    return zero and read as "not indexed." Prefer a single distinctive
+    symbol/term or a "quoted phrase". For concept-level recall (where a
+    miss may just be different wording), use hybrid_search/semantic_search
+    instead of concluding the symbol is absent. A zero result under a
+    project filter means absent from that project, not the whole workspace.
 
     Args:
-        query: Search query — can be a symbol name, code fragment, or natural language
+        query: Search query — a symbol name or code fragment (keyword/FTS, not semantic)
         kind: Optional filter: 'function', 'class', 'method', 'struct', 'enum', etc.
         project: Optional project filter (workspace mode only, e.g. 'intuition')
         limit: Max results to return (default 20)


### PR DESCRIPTION
Closes #22

## What

Docs-only clarification that `search_symbols` is keyword-exact (FTS5) and that a **bare multi-word query is implicitly ANDed** — every token must match the same symbol, so a long keyword list can return zero and read as "not indexed."

Verified against srclight's actual pipeline: `db.search_symbols` passes the raw `query` straight to FTS5 `MATCH`, so the caveat genuinely applies. `hybrid_search` (RRF fusion) and `semantic_search` dodge it, which the notes make explicit so agents route a keyword miss to those tools instead of concluding absence.

## Changes (3 spots)

- **`search_symbols` tool docstring** (`server.py`) — keyword/FTS semantics, quoted-phrase tip, project-filter caveat.
- **Server "Which Search Tool to Use" instructions** (`server.py` module docstring) — keyword-exact vs. semantic/hybrid routing.
- **README search-tool section** — new "Choosing a search tool" note + clarified `search_symbols` table row.

Also notes that a zero result under a `project` filter means "absent from that project," not the whole workspace.

No behavior change. `server.py` parses clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)