### PR TITLE
fix: complete the C/C++ call graph — pointer return types and prototype resolution

### DIFF
--- a/src/srclight/db.py
+++ b/src/srclight/db.py
@@ -636,12 +636,23 @@ class Database:
         self.conn.execute("DELETE FROM symbols WHERE file_id = ?", (file_id,))
 
     def get_symbol_by_name(self, name: str) -> SymbolRecord | None:
-        """Get first symbol matching exact name. Use get_symbols_by_name for all matches."""
+        """Get first symbol matching exact name. Use get_symbols_by_name for all matches.
+
+        In C and C++ a name resolves to both a declaration and a definition.
+        Edges hang off the definition, so an unordered LIMIT 1 landing on the
+        prototype makes callers and callees come back empty. Rank definitions
+        first, then prefer the row that carries edges.
+        """
         assert self.conn is not None
         row = self.conn.execute(
             """SELECT s.*, f.path as file_path FROM symbols s
                JOIN files f ON s.file_id = f.id
-               WHERE s.name = ? LIMIT 1""",
+               WHERE s.name = ?
+               ORDER BY CASE s.kind WHEN 'prototype' THEN 1 ELSE 0 END,
+                        (SELECT count(*) FROM symbol_edges e
+                          WHERE e.target_id = s.id OR e.source_id = s.id) DESC,
+                        s.id
+               LIMIT 1""",
             (name,),
         ).fetchone()
         if row is None:

--- a/src/srclight/indexer.py
+++ b/src/srclight/indexer.py
@@ -294,6 +294,10 @@ def _kind_from_capture(capture_name: str) -> str:
         "define": "macro",
         "proto": "prototype",
         "qproto": "prototype",
+        "ptrfn": "function",   # C/C++ pointer return types
+        "ptrfn2": "function",
+        "ptrproto": "prototype",
+        "ptrproto2": "prototype",
         "trait": "trait",
         "impl": "impl",
         "template": "template",

--- a/src/srclight/languages.py
+++ b/src/srclight/languages.py
@@ -44,6 +44,18 @@ _C_QUERY = """
     declarator: (function_declarator
         declarator: (identifier) @fn.name)) @fn.def
 
+; A `T*` return type wraps the declarator in a pointer_declarator, `T**` nests two.
+(function_definition
+    declarator: (pointer_declarator
+        declarator: (function_declarator
+            declarator: (identifier) @ptrfn.name))) @ptrfn.def
+
+(function_definition
+    declarator: (pointer_declarator
+        declarator: (pointer_declarator
+            declarator: (function_declarator
+                declarator: (identifier) @ptrfn2.name)))) @ptrfn2.def
+
 (struct_specifier
     name: (type_identifier) @struct.name) @struct.def
 
@@ -53,6 +65,17 @@ _C_QUERY = """
 (declaration
     declarator: (function_declarator
         declarator: (identifier) @proto.name)) @proto.def
+
+(declaration
+    declarator: (pointer_declarator
+        declarator: (function_declarator
+            declarator: (identifier) @ptrproto.name))) @ptrproto.def
+
+(declaration
+    declarator: (pointer_declarator
+        declarator: (pointer_declarator
+            declarator: (function_declarator
+                declarator: (identifier) @ptrproto2.name)))) @ptrproto2.def
 
 (type_definition
     declarator: (type_identifier) @typedef.name) @typedef.def
@@ -72,6 +95,23 @@ _CPP_QUERY = """
 (function_definition
     declarator: (function_declarator
         declarator: (qualified_identifier) @method.name)) @method.def
+
+; A `T*` return type wraps the declarator in a pointer_declarator, `T**` nests two.
+(function_definition
+    declarator: (pointer_declarator
+        declarator: (function_declarator
+            declarator: (identifier) @ptrfn.name))) @ptrfn.def
+
+(function_definition
+    declarator: (pointer_declarator
+        declarator: (pointer_declarator
+            declarator: (function_declarator
+                declarator: (identifier) @ptrfn2.name)))) @ptrfn2.def
+
+(declaration
+    declarator: (pointer_declarator
+        declarator: (function_declarator
+            declarator: (identifier) @ptrproto.name))) @ptrproto.def
 
 (class_specifier
     name: (type_identifier) @cls.name) @cls.def

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -124,6 +124,37 @@ def test_symbols_in_file(db):
     assert [s.name for s in syms] == ["foo", "bar", "baz"]
 
 
+def test_get_symbol_by_name_prefers_definition(db):
+    """A name shared by a prototype and a definition resolves to the definition.
+
+    Edges hang off the definition, so returning the prototype leaves callers
+    and callees empty.
+    """
+    file_id = db.upsert_file(FileRecord(
+        path="src/lib.c", content_hash="abc",
+        mtime=1000.0, language="c", size=100, line_count=20,
+    ))
+
+    # Prototype first, so an unordered LIMIT 1 would return it.
+    db.insert_symbol(SymbolRecord(
+        file_id=file_id, kind="prototype", name="node_create",
+        start_line=1, end_line=1, content="Node* node_create(int value);", line_count=1,
+    ), "src/lib.c")
+
+    definition_id = db.insert_symbol(SymbolRecord(
+        file_id=file_id, kind="function", name="node_create",
+        start_line=5, end_line=8, content="Node* node_create(int value) { return 0; }",
+        line_count=4,
+    ), "src/lib.c")
+
+    db.commit()
+
+    sym = db.get_symbol_by_name("node_create")
+    assert sym is not None
+    assert sym.id == definition_id
+    assert sym.kind == "function"
+
+
 def test_edges(db):
     """Can insert and query symbol relationships."""
     file_id = db.upsert_file(FileRecord(

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -142,6 +142,74 @@ def test_index_c(db, c_project):
     assert "main" in names
 
 
+@pytest.fixture
+def pointer_return_project(tmp_path):
+    """A C and a C++ file whose functions return pointers."""
+    src = tmp_path / "ptrproject"
+    src.mkdir()
+
+    (src / "alloc.c").write_text('''\
+typedef struct Node {
+    int value;
+} Node;
+
+Node* node_create(int value);
+Node** node_table(void);
+
+Node* node_create(int value) {
+    return 0;
+}
+
+Node** node_table(void) {
+    return 0;
+}
+
+Node* node_clone(Node* node) {
+    return node_create(node->value);
+}
+''')
+
+    (src / "alloc.cpp").write_text('''\
+struct Buffer {
+    int size;
+};
+
+Buffer* buffer_create(int size);
+
+Buffer* buffer_create(int size) {
+    return new Buffer{size};
+}
+''')
+
+    return src
+
+
+def test_index_pointer_returning_functions(db, pointer_return_project):
+    """Indexes C and C++ functions whose return type is a pointer."""
+    config = IndexConfig(root=pointer_return_project)
+    indexer = Indexer(db, config)
+    indexer.index(pointer_return_project)
+
+    c_syms = db.symbols_in_file("alloc.c")
+    assert {"node_create", "node_table", "node_clone"} <= {
+        s.name for s in c_syms if s.kind == "function"
+    }
+    assert {"node_create", "node_table"} <= {
+        s.name for s in c_syms if s.kind == "prototype"
+    }
+
+    cpp_syms = db.symbols_in_file("alloc.cpp")
+    assert "buffer_create" in {s.name for s in cpp_syms if s.kind == "function"}
+    assert "buffer_create" in {s.name for s in cpp_syms if s.kind == "prototype"}
+
+    # node_clone calls node_create, and both return a pointer. The edge exists
+    # only if both captures mapped to a kind: an unmapped one becomes "unknown",
+    # which EDGE_TARGET_KINDS filters out.
+    node_create = db.get_symbol_by_name("node_create")
+    assert node_create is not None
+    assert "node_clone" in [c["symbol"].name for c in db.get_callers(node_create.id)]
+
+
 def test_incremental_index(db, sample_project):
     """Incremental indexing skips unchanged files."""
     config = IndexConfig(root=sample_project)


### PR DESCRIPTION
Two independent bugs that together left large parts of a C/C++ call graph empty.
Found while indexing a C codebase of a few thousand files, where handles are
returned by pointer nearly everywhere.

## 1. Functions returning a pointer were never indexed

A `T*` return type wraps the declarator in a `pointer_declarator`, and `T**`
nests two of them:

    (function_definition
      type: (type_identifier)
      declarator: (pointer_declarator          <-- this level
        declarator: (function_declarator
          declarator: (identifier))))

The C and C++ queries only matched `function_definition` and `declaration` with
a `function_declarator` directly beneath, so none of these functions reached the
index — nor did any edge pointing at one.

Adds the pointer and pointer-to-pointer patterns for both definitions and
declarations, in both grammars.

The capture mapping matters just as much as the query: `_kind_from_capture`
falls through to `"unknown"` for an unmapped capture, and `EDGE_TARGET_KINDS`
filters that out. Without the mapping the symbols would be stored and still
never be reachable as an edge target, which is a more confusing failure than
being absent. Both parts are in the same commit for that reason.

## 2. `get_symbol_by_name` could return the prototype

It ran an unordered `LIMIT 1`. In C and C++ a name usually resolves to both a
declaration and a definition, and edges hang off the definition — so whenever
the prototype happened to come back first, `get_callers` and `get_callees`
reported nothing for a function that plainly had callers.

Now ordered: definitions ahead of prototypes, then whichever row actually
carries edges.

## Tests

- `test_index_pointer_returning_functions` — indexes a C file (`T*`, `T**`, and
  a prototype for each) and a C++ file, asserts both the `function` and
  `prototype` symbols exist, then asserts a call edge between two
  pointer-returning functions, which only resolves if the captures were mapped.
- `test_get_symbol_by_name_prefers_definition` — prototype inserted first, so an
  unordered `LIMIT 1` would return it.

Full suite: 339 passed, same 10 pre-existing failures as on the base commit
(`test_workspace` URI cases and `test_index_dart`, both environment-related).

## A note for whoever touches these queries next

An invalid pattern makes the **whole** query for that language fail to compile,
and indexing then reports zero errors while producing zero symbols for that
language. It is worth comparing per-language symbol counts before and after any
query change. In particular, `qualified_identifier` behind a pointer declarator
and `reference_declarator` are not valid in the C++ grammar.

---

Thanks for building this :) — it has become a daily tool for me on a large C/C++
codebase, and being able to pull a single function out of a five-thousand-line
file, or trace who calls what, is exactly what I needed. Hope these two fixes
are useful back.