### PR TITLE
perf: match symbol names by grouped lookup instead of one giant alternation

### DIFF
--- a/src/srclight/indexer.py
+++ b/src/srclight/indexer.py
@@ -278,11 +278,19 @@ def _extract_signature(source_bytes: bytes, node: Node, lang: str) -> str | None
 # `handler`, and a scanner that simply looked for identifier runs would report a
 # name that is really part of a larger word.
 _IS_WORD_CHAR = re.compile(r"\w").match
-# Identifier runs, as candidate starting points. The lookbehind is a filter, not
-# the guard: _on_boundary decides, and it is checked again at every candidate.
-# This only keeps positions out of the scan that would be rejected there anyway.
-_IDENT_RUN_RE = re.compile(r"(?<!\w)[A-Za-z_][A-Za-z0-9_]*")
-_LEADING_RUN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+# Identifier runs, as candidate starting points. The classes are Unicode: Python
+# and C# both allow `émetteur` as an identifier, and an ASCII-only head would
+# push every such name off the grouped path and back onto a scan of the whole
+# body, which is the cost this grouping exists to remove. `[^\W\d]` is a word
+# character that is not a digit.
+#
+# The lookbehind IS the guard for these positions, not a filter: the walk does
+# not re-check the leading boundary. A run starts on a word character and the
+# lookbehind refuses a word character before it, so exactly one side is a word
+# character — `\b`, by construction. Relax it and names inside larger words
+# (`123handler`, `caféhandler`) start matching.
+_IDENT_RUN_RE = re.compile(r"(?<!\w)[^\W\d]\w*")
+_LEADING_RUN_RE = re.compile(r"[^\W\d]\w*")
 
 
 def _on_boundary(content: str, index: int) -> bool:
@@ -320,41 +328,76 @@ def build_name_matcher(names: set[str]) -> Callable[[str], set[str]]:
     case that proves it -- accepting `Registry<T>::Lookup` must leave
     `Inner::Leaf` still findable.
     """
-    buckets: dict[str, list[str]] = {}
     # Names that do not begin with an identifier character (extraction can
     # produce a few). They cannot be reached from an identifier run, so they
     # are located directly.
     unanchored: list[str] = []
+    grouping: dict[str, list[str]] = {}
     for name in names:
         head = _LEADING_RUN_RE.match(name)
         if head is None:
             unanchored.append(name)
         else:
-            buckets.setdefault(head.group(0), []).append(name)
-    for candidates in buckets.values():
-        candidates.sort(key=len, reverse=True)
+            grouping.setdefault(head.group(0), []).append(name)
+    # Longest first, so the first candidate that matches at a position is the
+    # one the alternation would have chosen. Frozen into tuples: the scan hands
+    # these lists straight to the caller's walk, and a shared list that anything
+    # could append to is a trap waiting for the next change.
+    buckets = {
+        head: tuple(sorted(candidates, key=len, reverse=True))
+        for head, candidates in grouping.items()
+    }
 
-    def match(content: str) -> set[str]:
-        starts: dict[int, list[str]] = {}
+    def anchored_candidates(content: str):
+        """Identifier runs, in order, with the names that could start there.
+
+        The lookbehind in _IDENT_RUN_RE has already established the leading
+        boundary — the run begins on an identifier character and the character
+        before it is not a word character — so the walk need only check where
+        each candidate ENDS.
+        """
         for run in _IDENT_RUN_RE.finditer(content):
-            candidates = buckets.get(run.group(0))
-            if candidates is not None:
-                starts[run.start()] = candidates
+            names_here = buckets.get(run.group(0))
+            if names_here is not None:
+                yield run.start(), names_here
+
+    def all_candidates(content: str):
+        """The same, plus the names that no identifier run can reach.
+
+        Only used when such names exist. They carry no boundary guarantee, so
+        they are filtered here rather than in the walk.
+
+        Several of them can start at the SAME position, and the walk takes the
+        first candidate that matches — so they have to be grouped per position
+        and ordered longest first, exactly as the buckets are. Emitting them one
+        by one left the order to however the name set happened to iterate, and
+        `émetteur` would beat `émetteur.envoyer` about half the time.
+        """
+        by_start: dict[int, list[str]] = {}
         for name in unanchored:
             at = content.find(name)
             while at != -1:
-                starts.setdefault(at, []).append(name)
+                if _on_boundary(content, at):
+                    by_start.setdefault(at, []).append(name)
                 at = content.find(name, at + 1)
+
+        found_at = list(anchored_candidates(content))
+        found_at.extend(
+            (start, tuple(sorted(names_here, key=len, reverse=True)))
+            for start, names_here in by_start.items()
+        )
+        found_at.sort(key=lambda candidate: candidate[0])
+        return found_at
+
+    def match(content: str) -> set[str]:
+        candidates = all_candidates(content) if unanchored else anchored_candidates(content)
 
         found: set[str] = set()
         cursor = 0
-        for start in sorted(starts):
-            if start < cursor or not _on_boundary(content, start):
+        for start, names_here in candidates:
+            if start < cursor:
                 continue
-            candidates = starts[start]
-            if len(candidates) > 1 and unanchored:
-                candidates = sorted(candidates, key=len, reverse=True)
-            for name in candidates:
+            for name in names_here:
                 end = start + len(name)
                 if content.startswith(name, start) and _on_boundary(content, end):
                     found.add(name)
@@ -363,9 +406,6 @@ def build_name_matcher(names: set[str]) -> Callable[[str], set[str]]:
         return found
 
     return match
-
-
-
 
 
 def _kind_from_capture(capture_name: str) -> str:

--- a/src/srclight/indexer.py
+++ b/src/srclight/indexer.py
@@ -10,6 +10,7 @@ import fnmatch
 import hashlib
 import json
 import logging
+import re
 import subprocess
 import time
 from dataclasses import dataclass, field
@@ -270,6 +271,25 @@ def _extract_signature(source_bytes: bytes, node: Node, lang: str) -> str | None
             return source_bytes[node.start_byte:sig_end].decode("utf-8", errors="replace").strip()
 
     return None
+
+
+def build_name_matcher(names: set[str]) -> Callable[[str], set[str]]:
+    """Return a function mapping a symbol body to the known names it references.
+
+    Matching is leftmost, longest-at-that-position and non-overlapping: where
+    several names match at the same spot the longest one wins, and the shorter
+    names inside it are not reported. `Widget::~Widget` in a destructor body
+    therefore yields the destructor, never a bare `Widget`.
+    """
+    ordered = sorted(names, key=len, reverse=True)
+    if not ordered:
+        return lambda content: set()
+    pattern = re.compile(r"\b(" + "|".join(re.escape(n) for n in ordered) + r")\b")
+
+    def match(content: str) -> set[str]:
+        return set(pattern.findall(content))
+
+    return match
 
 
 def _kind_from_capture(capture_name: str) -> str:
@@ -1004,15 +1024,9 @@ class Indexer:
             if len(syms) <= MAX_SYMBOL_FANOUT
         }
 
-        # Pre-compile regex
-        sorted_names = sorted(filtered_names.keys(), key=len, reverse=True)
-        if not sorted_names:
+        if not filtered_names:
             return 0
-
-        import re
-        pattern = re.compile(
-            r"\b(" + "|".join(re.escape(n) for n in sorted_names) + r")\b"
-        )
+        match_names = build_name_matcher(set(filtered_names))
 
         def _dir_of(path: str) -> str:
             """Get directory component of a path."""
@@ -1111,7 +1125,7 @@ class Indexer:
             # prose is not a reference (12.8% of sampled edges were this class).
             content = mask_noncode(row["content"], row["language"] or "")
 
-            referenced_names = set(pattern.findall(content))
+            referenced_names = match_names(content)
             referenced_names.discard(source_name)
 
             imported = _imports_for(source_file, row["language"])

--- a/src/srclight/indexer.py
+++ b/src/srclight/indexer.py
@@ -273,19 +273,23 @@ def _extract_signature(source_bytes: bytes, node: Node, lang: str) -> str | None
     return None
 
 
-# Most symbol names are an identifier, or a `::` chain of them where any
-# segment after the first may carry a destructor `~`. The leading segment never
-# does: `~value` in source is a bitwise complement, and the name to find there
-# is `value`.
-#
-# Admitting `~` after a `::` is a matter of cost, not of correctness — the merge
-# below handles destructors either way. It keeps them out of the residual
-# alternation, which a C++ codebase would otherwise fill with one entry per
-# class.
-_NAME_HEAD = r"[A-Za-z_][A-Za-z0-9_]*"
-_NAME_SEG = r"~?[A-Za-z_][A-Za-z0-9_]*"
-_TOKEN_RE = re.compile(rf"{_NAME_HEAD}(?:::{_NAME_SEG})*")
-_TOKENISABLE_RE = re.compile(rf"^{_NAME_HEAD}(?:::{_NAME_SEG})*$")
+# `\b` is Unicode-aware, so a boundary depends on characters this module must
+# not assume are ASCII: `caféhandler` and `123handler` contain no boundary before
+# `handler`, and a scanner that simply looked for identifier runs would report a
+# name that is really part of a larger word.
+_IS_WORD_CHAR = re.compile(r"\w").match
+# Identifier runs, as candidate starting points. The lookbehind is a filter, not
+# the guard: _on_boundary decides, and it is checked again at every candidate.
+# This only keeps positions out of the scan that would be rejected there anyway.
+_IDENT_RUN_RE = re.compile(r"(?<!\w)[A-Za-z_][A-Za-z0-9_]*")
+_LEADING_RUN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def _on_boundary(content: str, index: int) -> bool:
+    """`\b` at `index`: exactly one side is a word character."""
+    before = index > 0 and _IS_WORD_CHAR(content[index - 1]) is not None
+    after = index < len(content) and _IS_WORD_CHAR(content[index]) is not None
+    return before != after
 
 
 def build_name_matcher(names: set[str]) -> Callable[[str], set[str]]:
@@ -297,82 +301,71 @@ def build_name_matcher(names: set[str]) -> Callable[[str], set[str]]:
     therefore yields the destructor, never a bare `Widget`.
 
     An alternation of every name expresses that directly, but Python's re
-    engine walks alternatives one by one at each position, so the cost grows
-    with the size of the name set: on a codebase with tens of thousands of
-    symbols it dominates indexing entirely.
+    engine walks alternatives one at a time at each position, so the cost grows
+    with the size of the name set rather than with the body being scanned. On a
+    codebase with tens of thousands of symbols it dominates indexing entirely.
 
-    Instead, tokenise the body once and look each token up. Names that do not
-    fit the token shape — operator overloads, templates, anything carrying
-    punctuation — keep an alternation of their own, necessarily a small one.
-    The two sets of candidates are then merged into a single leftmost-longest
-    walk, because running them as independent passes is NOT equivalent: a name
-    the alternation consumes whole would still be reported piecewise by the
-    tokeniser.
+    So group the names by their leading identifier instead. A name can only
+    begin where an identifier run begins on a boundary, so the run under the
+    cursor selects a handful of candidates by dictionary lookup, and the
+    longest one that the body actually starts with -- and that ends on a
+    boundary -- wins. `Vec<T>::push_back` and `Foo::operator+=` need no special
+    handling: they group under `Vec` and `Foo` like everything else, and the
+    punctuation is just part of the string being compared.
+
+    One scan, one cursor. Splitting the work over several passes and merging
+    the results afterwards is NOT equivalent, however carefully the merge is
+    written: once a match is accepted, the search has to RESUME inside what the
+    other passes had already scanned. `Registry<T>::Lookup::Inner::Leaf` is the
+    case that proves it -- accepting `Registry<T>::Lookup` must leave
+    `Inner::Leaf` still findable.
     """
-    if not names:
-        return lambda content: set()
-
-    tokenisable = {n for n in names if _TOKENISABLE_RE.match(n)}
-    residual = sorted(names - tokenisable, key=len, reverse=True)
-    residual_re = (
-        re.compile(r"\b(" + "|".join(re.escape(n) for n in residual) + r")\b")
-        if residual
-        else None
-    )
+    buckets: dict[str, list[str]] = {}
+    # Names that do not begin with an identifier character (extraction can
+    # produce a few). They cannot be reached from an identifier run, so they
+    # are located directly.
+    unanchored: list[str] = []
+    for name in names:
+        head = _LEADING_RUN_RE.match(name)
+        if head is None:
+            unanchored.append(name)
+        else:
+            buckets.setdefault(head.group(0), []).append(name)
+    for candidates in buckets.values():
+        candidates.sort(key=len, reverse=True)
 
     def match(content: str) -> set[str]:
-        spans: list[tuple[int, int, str]] = []
+        starts: dict[int, list[str]] = {}
+        for run in _IDENT_RUN_RE.finditer(content):
+            candidates = buckets.get(run.group(0))
+            if candidates is not None:
+                starts[run.start()] = candidates
+        for name in unanchored:
+            at = content.find(name)
+            while at != -1:
+                starts.setdefault(at, []).append(name)
+                at = content.find(name, at + 1)
 
-        for token_match in _TOKEN_RE.finditer(content):
-            token = token_match.group(0)
-            base = token_match.start()
-            if "::" not in token:
-                if token in tokenisable:
-                    spans.append((base, token_match.end(), token))
+        found: set[str] = set()
+        cursor = 0
+        for start in sorted(starts):
+            if start < cursor or not _on_boundary(content, start):
                 continue
-            # Walk the chain: at each segment take the longest run of segments
-            # that is a known name, then resume after it. A segment start is
-            # always a word boundary, so an inner run can match on its own.
-            segments = token.split("::")
-            offsets = []
-            offset = 0
-            for segment in segments:
-                offsets.append(offset)
-                offset += len(segment) + 2
-            i = 0
-            while i < len(segments):
-                for j in range(len(segments), i, -1):
-                    candidate = "::".join(segments[i:j])
-                    if candidate in tokenisable:
-                        start = base + offsets[i]
-                        spans.append((start, start + len(candidate), candidate))
-                        i = j
-                        break
-                else:
-                    i += 1
-
-        if residual_re is not None:
-            for residual_match in residual_re.finditer(content):
-                spans.append(
-                    (residual_match.start(1), residual_match.end(1), residual_match.group(1))
-                )
-            # Only the merge below can decide between an untokenisable name and
-            # the tokens inside it, so it has to see both.
-            spans.sort(key=lambda span: (span[0], -(span[1] - span[0])))
-            found: set[str] = set()
-            cursor = 0
-            for start, end, name in spans:
-                if start < cursor:
-                    continue
-                found.add(name)
-                cursor = end
-            return found
-
-        # No untokenisable names: the token walk is already leftmost-longest
-        # and non-overlapping, so its spans need no reconciliation.
-        return {name for _, _, name in spans}
+            candidates = starts[start]
+            if len(candidates) > 1 and unanchored:
+                candidates = sorted(candidates, key=len, reverse=True)
+            for name in candidates:
+                end = start + len(name)
+                if content.startswith(name, start) and _on_boundary(content, end):
+                    found.add(name)
+                    cursor = end
+                    break
+        return found
 
     return match
+
+
+
 
 
 def _kind_from_capture(capture_name: str) -> str:
@@ -1247,7 +1240,6 @@ class Indexer:
         Returns the number of edges created.
         """
         assert self.db.conn is not None
-        import re
 
         # Get all class/struct symbols
         class_rows = self.db.conn.execute(

--- a/src/srclight/indexer.py
+++ b/src/srclight/indexer.py
@@ -273,6 +273,21 @@ def _extract_signature(source_bytes: bytes, node: Node, lang: str) -> str | None
     return None
 
 
+# Most symbol names are an identifier, or a `::` chain of them where any
+# segment after the first may carry a destructor `~`. The leading segment never
+# does: `~value` in source is a bitwise complement, and the name to find there
+# is `value`.
+#
+# Admitting `~` after a `::` is a matter of cost, not of correctness — the merge
+# below handles destructors either way. It keeps them out of the residual
+# alternation, which a C++ codebase would otherwise fill with one entry per
+# class.
+_NAME_HEAD = r"[A-Za-z_][A-Za-z0-9_]*"
+_NAME_SEG = r"~?[A-Za-z_][A-Za-z0-9_]*"
+_TOKEN_RE = re.compile(rf"{_NAME_HEAD}(?:::{_NAME_SEG})*")
+_TOKENISABLE_RE = re.compile(rf"^{_NAME_HEAD}(?:::{_NAME_SEG})*$")
+
+
 def build_name_matcher(names: set[str]) -> Callable[[str], set[str]]:
     """Return a function mapping a symbol body to the known names it references.
 
@@ -280,14 +295,82 @@ def build_name_matcher(names: set[str]) -> Callable[[str], set[str]]:
     several names match at the same spot the longest one wins, and the shorter
     names inside it are not reported. `Widget::~Widget` in a destructor body
     therefore yields the destructor, never a bare `Widget`.
+
+    An alternation of every name expresses that directly, but Python's re
+    engine walks alternatives one by one at each position, so the cost grows
+    with the size of the name set: on a codebase with tens of thousands of
+    symbols it dominates indexing entirely.
+
+    Instead, tokenise the body once and look each token up. Names that do not
+    fit the token shape — operator overloads, templates, anything carrying
+    punctuation — keep an alternation of their own, necessarily a small one.
+    The two sets of candidates are then merged into a single leftmost-longest
+    walk, because running them as independent passes is NOT equivalent: a name
+    the alternation consumes whole would still be reported piecewise by the
+    tokeniser.
     """
-    ordered = sorted(names, key=len, reverse=True)
-    if not ordered:
+    if not names:
         return lambda content: set()
-    pattern = re.compile(r"\b(" + "|".join(re.escape(n) for n in ordered) + r")\b")
+
+    tokenisable = {n for n in names if _TOKENISABLE_RE.match(n)}
+    residual = sorted(names - tokenisable, key=len, reverse=True)
+    residual_re = (
+        re.compile(r"\b(" + "|".join(re.escape(n) for n in residual) + r")\b")
+        if residual
+        else None
+    )
 
     def match(content: str) -> set[str]:
-        return set(pattern.findall(content))
+        spans: list[tuple[int, int, str]] = []
+
+        for token_match in _TOKEN_RE.finditer(content):
+            token = token_match.group(0)
+            base = token_match.start()
+            if "::" not in token:
+                if token in tokenisable:
+                    spans.append((base, token_match.end(), token))
+                continue
+            # Walk the chain: at each segment take the longest run of segments
+            # that is a known name, then resume after it. A segment start is
+            # always a word boundary, so an inner run can match on its own.
+            segments = token.split("::")
+            offsets = []
+            offset = 0
+            for segment in segments:
+                offsets.append(offset)
+                offset += len(segment) + 2
+            i = 0
+            while i < len(segments):
+                for j in range(len(segments), i, -1):
+                    candidate = "::".join(segments[i:j])
+                    if candidate in tokenisable:
+                        start = base + offsets[i]
+                        spans.append((start, start + len(candidate), candidate))
+                        i = j
+                        break
+                else:
+                    i += 1
+
+        if residual_re is not None:
+            for residual_match in residual_re.finditer(content):
+                spans.append(
+                    (residual_match.start(1), residual_match.end(1), residual_match.group(1))
+                )
+            # Only the merge below can decide between an untokenisable name and
+            # the tokens inside it, so it has to see both.
+            spans.sort(key=lambda span: (span[0], -(span[1] - span[0])))
+            found: set[str] = set()
+            cursor = 0
+            for start, end, name in spans:
+                if start < cursor:
+                    continue
+                found.add(name)
+                cursor = end
+            return found
+
+        # No untokenisable names: the token walk is already leftmost-longest
+        # and non-overlapping, so its spans need no reconciliation.
+        return {name for _, _, name in spans}
 
     return match
 

--- a/tests/test_edge_matcher.py
+++ b/tests/test_edge_matcher.py
@@ -1,0 +1,179 @@
+"""The name matcher behind the call graph.
+
+_build_edges scans every symbol body for references to known symbol names. The
+matching has to survive C++ name shapes that are easy to get wrong: qualified
+chains, destructors, and names carrying characters no tokeniser can split on.
+
+The end-to-end tests pin behaviour observed on the alternation implementation,
+so they stay meaningful across any change of matching strategy. The property
+test compares the matcher against a reference alternation built in the test
+itself — the shapes it covers are the ones the extractor does not produce from
+a small fixture, but which a real C++ codebase does.
+"""
+
+import re
+
+import pytest
+
+from srclight.db import Database
+from srclight.indexer import IndexConfig, Indexer, build_name_matcher
+
+
+@pytest.fixture
+def db(tmp_path):
+    db_path = tmp_path / "test.db"
+    db = Database(db_path)
+    db.open()
+    db.initialize()
+    yield db
+    db.close()
+
+
+@pytest.fixture
+def cpp_project(tmp_path):
+    """C++ names the matcher has to get right. Every name clears the noise
+    filters of _build_edges (length >= 4, not in NOISE_NAMES)."""
+    src = tmp_path / "cppproj"
+    src.mkdir()
+
+    (src / "widget.hpp").write_text('''\
+struct WidgetPanel {
+    int slot_value;
+};
+
+struct PanelRegistry {
+    static int lookup_slot(void);
+};
+
+struct ExtensionHost {
+    static PanelRegistry registry_for(void);
+};
+''')
+
+    (src / "widget.cpp").write_text('''\
+#include "widget.hpp"
+
+WidgetPanel::~WidgetPanel() {
+    slot_value = 0;
+}
+
+int mask_value(void) {
+    return 7;
+}
+
+int clear_mask(void) {
+    return ~mask_value();
+}
+
+int outer_caller(void) {
+    return ExtensionHost::PanelRegistry::lookup_slot();
+}
+''')
+
+    return src
+
+
+def _calls(db, source_name: str) -> set[str]:
+    return {
+        row["name"]
+        for row in db.conn.execute(
+            """SELECT t.name AS name FROM symbol_edges e
+               JOIN symbols s ON e.source_id = s.id
+               JOIN symbols t ON e.target_id = t.id
+               WHERE e.edge_type = 'calls' AND s.name = ?""",
+            (source_name,),
+        )
+    }
+
+
+@pytest.fixture
+def indexed(db, cpp_project):
+    Indexer(db, IndexConfig(root=cpp_project)).index(cpp_project)
+    return db
+
+
+def test_qualified_chain_yields_every_known_segment(indexed):
+    """`A::B::c()` references A, B and c when each is a known symbol.
+
+    The chain is not itself a symbol name, so the matcher has to walk it
+    segment by segment rather than treat it as one opaque token.
+    """
+    assert {"ExtensionHost", "PanelRegistry", "lookup_slot"} <= _calls(indexed, "outer_caller")
+
+
+def test_destructor_body_does_not_reference_its_own_class(indexed):
+    """`WidgetPanel::~WidgetPanel` must not yield a bare `WidgetPanel`.
+
+    The destructor's own qualified name appears in its body, and it is the
+    longest name matching at that position, so it is consumed whole and
+    discarded as a self-reference. A matcher that handles destructors in a
+    separate pass emits the class name as well and invents an edge.
+    """
+    assert "WidgetPanel" not in _calls(indexed, "WidgetPanel::~WidgetPanel")
+
+
+def test_bitwise_complement_does_not_hide_the_name(indexed):
+    """`~mask_value()` is a complement applied to a call, not a destructor.
+
+    A matcher that lets a token start with `~` swallows the identifier and
+    loses the reference — far more common in C than destructors.
+    """
+    assert "mask_value" in _calls(indexed, "clear_mask")
+
+
+# --- property: the matcher agrees with a reference alternation ---------------
+
+def _reference_matcher(names):
+    """The alternation _build_edges used before, kept as the oracle.
+
+    One regex, alternatives ordered longest-first, so at any position the
+    longest name wins and shorter names inside it never surface.
+    """
+    ordered = sorted(names, key=len, reverse=True)
+    pattern = re.compile(r"\b(" + "|".join(re.escape(n) for n in ordered) + r")\b")
+    return lambda content: set(pattern.findall(content))
+
+
+REFERENCE_CASES = [
+    pytest.param(
+        {"Registry", "Registry::Lookup", "Extension"},
+        "Extension::Registry::Lookup();",
+        id="longest-qualified-name-wins-over-its-prefix",
+    ),
+    pytest.param(
+        {"Widget", "Widget::~Widget"},
+        "Widget::~Widget() { reset(); }",
+        id="destructor-consumes-the-class-name",
+    ),
+    pytest.param(
+        {"mask_value", "Widget::~Widget"},
+        "return ~mask_value();",
+        id="complement-is-not-a-destructor",
+    ),
+    pytest.param(
+        # A name no tokeniser can split on, overlapping names that it can.
+        {"ObjectExtension", "Register", "ObjectExtension::Register<T>::Ident"},
+        "return ObjectExtension::Register<T>::Ident;",
+        id="untokenisable-name-shadows-the-names-inside-it",
+    ),
+    pytest.param(
+        {"MessageBox", "MessageBox::operator+="},
+        "MessageBox::operator+=(other);",
+        id="operator-overload",
+    ),
+    pytest.param(
+        {"Buffer", "Buffer::Inner", "Buffer::Inner::Leaf"},
+        "Buffer::Inner::Leaf a; Buffer::Inner b; Buffer c;",
+        id="nested-chains-of-decreasing-length",
+    ),
+    pytest.param(
+        {"handle", "handler", "handle_event"},
+        "handle_event(); handler(); handle();",
+        id="names-that-are-prefixes-of-each-other",
+    ),
+]
+
+
+@pytest.mark.parametrize("names,content", REFERENCE_CASES)
+def test_matcher_agrees_with_reference_alternation(names, content):
+    assert build_name_matcher(names)(content) == _reference_matcher(names)(content)

--- a/tests/test_edge_matcher.py
+++ b/tests/test_edge_matcher.py
@@ -11,6 +11,7 @@ itself — the shapes it covers are the ones the extractor does not produce from
 a small fixture, but which a real C++ codebase does.
 """
 
+import random
 import re
 
 import pytest
@@ -157,9 +158,45 @@ REFERENCE_CASES = [
         id="untokenisable-name-shadows-the-names-inside-it",
     ),
     pytest.param(
+        # `\b` after `=` needs a word character next, so a name ending in
+        # punctuation cannot match before `(`. Both matchers see only the class.
         {"MessageBox", "MessageBox::operator+="},
         "MessageBox::operator+=(other);",
-        id="operator-overload",
+        id="punctuation-terminated-name-cannot-match-before-a-bracket",
+    ),
+    pytest.param(
+        {"MessageBox", "MessageBox::operator+="},
+        "MessageBox::operator+=x;",
+        id="punctuation-terminated-name-matches-before-a-word-character",
+    ),
+    pytest.param(
+        # Accepting the first name must leave the rest of the chain findable.
+        {"Registry<T>::Lookup", "Lookup::Inner", "Inner::Leaf"},
+        "return Registry<T>::Lookup::Inner::Leaf;",
+        id="search-resumes-inside-a-chain-after-a-match",
+    ),
+    pytest.param(
+        {"Foo<T>::bar", "bar::baz", "baz"},
+        "Foo<T>::bar::baz();",
+        id="search-resumes-after-a-template-qualified-name",
+    ),
+    pytest.param(
+        # No boundary before `handler` here, in either case.
+        {"handler"},
+        "cafehandler; 123handler; caféhandler;",
+        id="a-name-inside-a-larger-word-is-not-a-reference",
+    ),
+    pytest.param(
+        {"Widget"},
+        "x = 1Widget;",
+        id="a-name-after-a-digit-is-not-a-reference",
+    ),
+    pytest.param(
+        # The boundary is between `~` and the class, so the bare name matches
+        # even when what precedes `::~` is unknown.
+        {"Widget", "Alias"},
+        "p->Alias::~Widget(); MyWidget::~Widget();",
+        id="explicit-destructor-call-yields-the-class",
     ),
     pytest.param(
         {"Buffer", "Buffer::Inner", "Buffer::Inner::Leaf"},
@@ -177,3 +214,31 @@ REFERENCE_CASES = [
 @pytest.mark.parametrize("names,content", REFERENCE_CASES)
 def test_matcher_agrees_with_reference_alternation(names, content):
     assert build_name_matcher(names)(content) == _reference_matcher(names)(content)
+
+
+def test_matcher_agrees_with_reference_on_random_input():
+    """Fuzz the two against each other.
+
+    The cases above are the shapes that were known to be hard. This looks for
+    the ones that are not: names and bodies are assembled from the same pool of
+    fragments, so collisions, prefixes and partial chains occur often.
+    """
+    rng = random.Random(20240607)
+    fragments = ["Widget", "Registry", "Lookup", "Inner", "handler", "value", "Wid", "handle"]
+    punctuation = ["::", "::~", "<T>::", "(", ")", ";", " ", ".", "->", "~", "1", "é", "_"]
+
+    pieces = fragments + ["::", "<T>::", "::~"]
+    for _ in range(400):
+        names = {
+            "".join(rng.choice(pieces) for _ in range(rng.randint(1, 3)))
+            for _ in range(rng.randint(1, 6))
+        }
+        names = {n for n in names if len(n) >= 4}
+        if not names:
+            continue
+        content = "".join(
+            rng.choice(fragments + punctuation) for _ in range(rng.randint(4, 40))
+        )
+        assert build_name_matcher(names)(content) == _reference_matcher(names)(content), (
+            f"names={names!r} content={content!r}"
+        )

--- a/tests/test_edge_matcher.py
+++ b/tests/test_edge_matcher.py
@@ -216,6 +216,24 @@ def test_matcher_agrees_with_reference_alternation(names, content):
     assert build_name_matcher(names)(content) == _reference_matcher(names)(content)
 
 
+def test_longest_wins_among_names_that_share_a_start_position():
+    """Names unreachable from an identifier run still compete by length.
+
+    Several of them can begin at the same index, and the walk takes the first
+    that matches — so they have to be ordered longest first. Emitted one at a
+    time they inherit whatever order the name set iterated in, which for strings
+    varies between processes, so the wrong one wins at random.
+
+    Every candidate has to END on a boundary too, or the shorter ones are
+    rejected there and the length ordering is never exercised — which is why
+    the names are `::` chains: each one stops in front of a `:` or the `;`.
+    """
+    for depth in range(2, 12):
+        names = {"::seg" * n for n in range(1, depth + 1)}
+        content = "y" + "::seg" * depth + ";"
+        assert build_name_matcher(names)(content) == _reference_matcher(names)(content)
+
+
 def test_matcher_agrees_with_reference_on_random_input():
     """Fuzz the two against each other.
 
@@ -224,11 +242,18 @@ def test_matcher_agrees_with_reference_on_random_input():
     fragments, so collisions, prefixes and partial chains occur often.
     """
     rng = random.Random(20240607)
-    fragments = ["Widget", "Registry", "Lookup", "Inner", "handler", "value", "Wid", "handle"]
-    punctuation = ["::", "::~", "<T>::", "(", ")", ";", " ", ".", "->", "~", "1", "é", "_"]
+    # Non-ASCII and punctuation-leading fragments matter: a name whose first
+    # character is not an ASCII letter cannot be reached from an identifier run,
+    # and several such names can start at the same position — which is where
+    # ordering is easiest to lose.
+    fragments = [
+        "Widget", "Registry", "Lookup", "Inner", "handler", "value", "Wid", "handle",
+        "émetteur", "Ünicode", "envoyer",
+    ]
+    punctuation = ["::", "::~", "<T>::", "(", ")", ";", " ", ".", "->", "~", "1", "é", "_", "&"]
 
-    pieces = fragments + ["::", "<T>::", "::~"]
-    for _ in range(400):
+    pieces = fragments + ["::", "<T>::", "::~", "&", "."]
+    for _ in range(2000):
         names = {
             "".join(rng.choice(pieces) for _ in range(rng.randint(1, 3)))
             for _ in range(rng.randint(1, 6))


### PR DESCRIPTION
`_build_edges` compiled one regex alternating over every known symbol name, then
ran it against every symbol body. Python's `re` engine walks alternatives one at
a time at each position, so the cost scales with the size of the name set rather
than with the body being scanned.

On a 3,107-file C/C++ repository that turned out to be **700s of a 786s
reindex** — for ten changed files, because the call graph is rebuilt whole
whenever anything changes. The rest of that reindex: scanning and hashing all
3,107 files took under a second, community detection 3.2s, embeddings 37s.

## The change

Group the names by their leading identifier. A name can only begin where an
identifier run begins on a word boundary, so the run under the cursor selects a
handful of candidates by dictionary lookup, and the longest one the body
actually starts with — and that ends on a boundary — wins. Then the cursor
advances past it.

`Vec<T>::push_back` and `Foo::operator+=` need no special handling: they group
under `Vec` and `Foo` like everything else, and the punctuation is simply part of
the string being compared.

**One scan, one cursor.** Splitting the work across passes and merging the
results afterwards is not equivalent, however carefully the merge is written:
once a match is accepted the search has to *resume inside* what the other passes
already covered. With names `{Registry<T>::Lookup, Lookup::Inner, Inner::Leaf}`
and body `Registry<T>::Lookup::Inner::Leaf`, accepting the first name must leave
`Inner::Leaf` findable. A merge cannot reconstruct that; a single cursor gets it
for free.

Boundaries are checked with `\b` semantics rather than an ASCII approximation.
`\b` is Unicode-aware, so `caféhandler`, `123handler` and `1Widget` contain no
boundary before the name that follows — a scanner that simply looked for
identifier runs would report a name that is part of a larger word, and fabricate
an edge. The character classes are Unicode for the same reason: Python and C#
both allow `émetteur` as an identifier, and an ASCII-only head would push every
such name off the grouped path onto a whole-body scan of its own.

## Evidence

Measured on 3,107 files, 51,533 symbols, 38,132 candidate names, with
`PYTHONHASHSEED` fixed so the existing set-iteration order does not add noise:

    _build_edges, alternation  : 132,695 edges in 679.2s
    _build_edges, grouped scan : 132,695 edges in  10.0s

The two `symbol_edges` tables are **identical row for row** — same names, same
edge types, same confidences, same resolutions.

## Tests

The first commit is a pure extraction — the alternation moves into
`build_name_matcher` unchanged — plus the tests that were missing. They pass
before the optimisation, which is what makes them a regression net rather than a
description of the new code:

- a qualified chain `A::B::c()` yields each known segment;
- a destructor body does not yield its own bare class name, because the qualified
  destructor is the longest name matching there and is consumed whole;
- `~mask_value()` is a complement applied to a call, and still yields the name;
- an explicit destructor call qualified by an alias yields the class, since the
  boundary sits between `~` and the class name;
- a name ending in punctuation cannot match before a bracket, and does match
  before a word character;
- the search resumes inside a chain after a match;
- a name inside a larger word, or after a digit, is not a reference;
- several names that cannot be reached from an identifier run, sharing one start
  position, are still resolved longest first;
- a property test against a reference alternation built in the test, and a fuzz
  of 2,000 generated name-set/body pairs against the same reference.

Each guard was checked by removing it:

| removed | result |
|---|---|
| the boundary check | fails the punctuation case and the fuzz |
| the search resuming after a match | fails the chain case |
| length ordering among names at one position | fails the shared-position case |

Worth recording for the next reader: the `(?<!\w)` lookbehind on the identifier
scan **is** the guard for those positions, not a filter — the walk does not
re-check the leading boundary. A run starts on a word character and the
lookbehind refuses a word character before it, which is `\b` by construction.
Relax it for speed and names inside larger words start matching.

Full suite: 357 passed, with the same 10 failures present on the base commit
(`test_workspace` URI cases and `test_index_dart`, both environment-related).

## What this does not cover

The repository measured is C and C++. Of the 18 supported languages the suite
exercises few, and the name shapes of the others are untested here. Names that do
not begin with an identifier character cannot be reached from an identifier run
and are located directly instead; that path exists for the handful of extraction
artefacts that produce such names, and has only been exercised against them.

One property worth stating because it bounds what "identical" can mean:
`referenced_names` is a set, iterated with a cap of `MAX_REFS_PER_SYMBOL`, so
with a randomised hash seed the current code already differs between runs for
symbols above that cap — 257 of 51,166, 0.5%, on the repository measured. This
change does not affect that, and the comparison above pins the seed to isolate
it.