### PR TITLE
feat: index Lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ AI coding agents (Claude Code, Cursor, etc.) spend **40-60% of their tokens on o
 - **Minimal dependencies** — single SQLite file per repo, no Docker/Redis/vector DB
 - **Fully offline** — no API calls, works air-gapped (Ollama local embeddings)
 - **Incremental** — only re-indexes changed files (content hash detection)
-- **11 languages** — Python, C, C++, C#, JavaScript, TypeScript, PHP, Dart, Swift, Kotlin, Java, Go
+- **12 languages** — Python, C, C++, C#, JavaScript, TypeScript, PHP, Lua, Dart, Swift, Kotlin, Java, Go
 - **10 document formats** — PDF, DOCX, XLSX, HTML, CSV/TSV, email (.eml), images (PNG/JPG/SVG/etc.), plain text, RST, Markdown
 - **Optional OCR** — PaddleOCR for scanned/image-only PDF pages; pytesseract for images
 - **4 search modes** — symbol names, source code (trigram), documentation (stemmed), semantic (embeddings)
@@ -544,7 +544,7 @@ A survey of 50+ MCP code intelligence servers across all major registries (Offic
 | Multi-repo workspace | ATTACH+UNION | None | None | None |
 | Infrastructure required | `pip install`, SQLite | None | SCIP indexer | Docker, Milvus, OpenAI API |
 | Fully local / private | Yes, zero API calls | Yes | Yes | No (needs OpenAI) |
-| Languages | 11 | Any (regex) | 5 (SCIP) | Any (chunking) |
+| Languages | 12 | Any (regex) | 5 (SCIP) | Any (chunking) |
 | MCP tools | 42 | 2 (grep, glob) | 80+ | ~10 |
 
 Unlike grep-based tools, srclight builds a persistent index with structured lookups. Unlike cloud-based solutions, everything runs locally — your code never leaves your machine. Unlike IDE plugins, srclight works with any MCP client.

--- a/packaging/pyinstaller/srclight.spec
+++ b/packaging/pyinstaller/srclight.spec
@@ -46,6 +46,7 @@ TREE_SITTER_PACKAGES = [
     "tree_sitter_swift",
     "tree_sitter_kotlin",
     "tree_sitter_markdown",
+    "tree_sitter_lua",
 ]
 
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "tree-sitter-cmake>=0.7.0",
     "tree-sitter-sql>=0.3.0",
     "tree-sitter-groovy>=0.1.0",
+    "tree-sitter-lua>=0.5.0",
     "numpy>=1.26.0",
     "networkx>=3.0",
 ]

--- a/src/srclight/db.py
+++ b/src/srclight/db.py
@@ -636,12 +636,23 @@ class Database:
         self.conn.execute("DELETE FROM symbols WHERE file_id = ?", (file_id,))
 
     def get_symbol_by_name(self, name: str) -> SymbolRecord | None:
-        """Get first symbol matching exact name. Use get_symbols_by_name for all matches."""
+        """Get first symbol matching exact name. Use get_symbols_by_name for all matches.
+
+        In C and C++ a name resolves to both a declaration and a definition.
+        Edges hang off the definition, so an unordered LIMIT 1 landing on the
+        prototype makes callers and callees come back empty. Rank definitions
+        first, then prefer the row that carries edges.
+        """
         assert self.conn is not None
         row = self.conn.execute(
             """SELECT s.*, f.path as file_path FROM symbols s
                JOIN files f ON s.file_id = f.id
-               WHERE s.name = ? LIMIT 1""",
+               WHERE s.name = ?
+               ORDER BY CASE s.kind WHEN 'prototype' THEN 1 ELSE 0 END,
+                        (SELECT count(*) FROM symbol_edges e
+                          WHERE e.target_id = s.id OR e.source_id = s.id) DESC,
+                        s.id
+               LIMIT 1""",
             (name,),
         ).fetchone()
         if row is None:

--- a/src/srclight/imports.py
+++ b/src/srclight/imports.py
@@ -10,7 +10,19 @@ from __future__ import annotations
 
 import re
 
+from .refmask import mask_noncode
+
 __all__ = ["IMPORT_PATTERNS", "extract_imports"]
+
+# Nothing may precede the loader's name: `self.require(x)` is some table's own
+# method, and `myrequire(x)` somebody else's function.
+_LUA_CALLER = r"(?<![\w.:])"
+# A quoted path. The two quote styles are separate branches rather than one
+# character class so that `include('a")` cannot match across them, and so an
+# apostrophe inside a double-quoted path survives. A `.lua` suffix comes off:
+# consumers reduce a module to the name it ends in, and a module keeping its
+# extension reduces to "lua".
+_LUA_PATH = r"""(?:"([^"]+?)(?i:\.lua)?"|'([^']+?)(?i:\.lua)?')"""
 
 # Import extraction patterns by language (regex-based, not tree-sitter)
 IMPORT_PATTERNS: dict[str, list[str]] = {
@@ -37,6 +49,12 @@ IMPORT_PATTERNS: dict[str, list[str]] = {
         r"^use\s+([\w\\]+)",
         r"(?:require|include)(?:_once)?\s*['\"]([^'\"]+)['\"]",
     ],
+    # `require` is standard Lua; embedding hosts add their own loader, and
+    # Garry's Mod's include/AddCSLuaFile is common enough to be worth matching.
+    "lua": [
+        rf"{_LUA_CALLER}require\s*\(?\s*{_LUA_PATH}",
+        rf"{_LUA_CALLER}(?:include|AddCSLuaFile)\s*\(?\s*{_LUA_PATH}",
+    ],
 }
 
 
@@ -48,6 +66,15 @@ def extract_imports(content: str, language: str) -> list[dict]:
 
     imports = []
     seen_statements = set()
+
+    if language == "lua":
+        # Blank the comments before scanning. A line-oriented pass cannot do it:
+        # `--` need not start the line, `--[[ ]]` spans several, and callers pass
+        # a truncated head that can cut the closing `]]` off entirely. Strings
+        # are left alone, since the module name is inside one; a `require`
+        # written inside some other string therefore still matches, as it does
+        # for every language here.
+        content = mask_noncode(content, language, mask_strings=False)
 
     for line in content.splitlines():
         stripped = line.strip()

--- a/src/srclight/indexer.py
+++ b/src/srclight/indexer.py
@@ -10,6 +10,7 @@ import fnmatch
 import hashlib
 import json
 import logging
+import re
 import subprocess
 import time
 from dataclasses import dataclass, field
@@ -269,6 +270,203 @@ def _extract_signature(source_bytes: bytes, node: Node, lang: str) -> str | None
                        name_node.end_byte)
             return source_bytes[node.start_byte:sig_end].decode("utf-8", errors="replace").strip()
 
+    elif lang == "lua":
+        # Lua declares no return type, so the parameter list ends the signature.
+        # It may hang off the node itself (`function f(a)`) or off the value it
+        # is assigned (`f = function(a)`), which is the same definition.
+        params = _lua_parameters(node)
+        if params is not None:
+            return source_bytes[node.start_byte:params.end_byte].decode(
+                "utf-8", errors="replace").strip()
+
+    return None
+
+
+def _lua_nameless_definition(node: Node) -> bool:
+    """True when a definition has no name a caller could write.
+
+    A computed key — `{ [k] = function() end }` — is one: `k` holds the key
+    rather than being it. A string key does name the function, and the query
+    captures it from inside the string.
+    """
+    if node.type == "field":
+        if node.child_count == 0 or node.child(0).type != "[":
+            return False
+        key = node.child_by_field_name("name")
+        return key is None or key.type != "string"
+
+    # An assignment target that is not a path names nothing either: a call, a
+    # parenthesised expression. Its source text would carry newlines and
+    # punctuation into the name index in place of a name. This asks the shape
+    # of the target, not whether a dotted path can be spelled from it —
+    # `t["my-key"]` has no dotted form and still names its function.
+    if node.type == "variable_declaration":
+        inner = node.named_children[0] if node.named_children else None
+        return inner is None or _lua_nameless_definition(inner)
+
+    if node.type == "assignment_statement":
+        return not _lua_is_path(node.child_by_field_name("name"))
+
+    return False
+
+
+def _lua_is_path(node: Node | None) -> bool:
+    """Whether a node is a name or a chain of index expressions ending in one."""
+    while node is not None and node.type != "identifier":
+        if node.type not in (
+            "dot_index_expression", "bracket_index_expression", "method_index_expression",
+        ):
+            return False
+        node = node.child_by_field_name("table")
+    return node is not None
+
+
+def _lua_definition_path(node: Node) -> str | None:
+    """The full path a Lua definition hangs off, e.g. `Stack:pop` or `von.Entity`.
+
+    The name a call site writes is not always the whole path, so the path is
+    kept as the qualified name. `t["k"]` is written as the dotted path it is
+    equivalent to: a qualified name carrying quotes and brackets matches
+    nothing a reader or a caller would write.
+    """
+    if node.type == "field":
+        name = _lua_key_name(node.child_by_field_name("name"))
+        if name is None:
+            return None
+        table = _lua_enclosing_table(node)
+        return f"{table}.{name}" if table else name
+
+    if node.type == "variable_declaration":
+        inner = node.named_children[0] if node.named_children else None
+        return _lua_definition_path(inner) if inner is not None else None
+
+    return _lua_target_path(node.child_by_field_name("name"))
+
+
+# A key only joins a dotted path if it could have been written as one.
+_LUA_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _lua_key_name(node: Node | None) -> str | None:
+    """A table key as a path segment, or None if it cannot be written as one."""
+    if node is None:
+        return None
+    if node.type == "string":
+        content = node.child_by_field_name("content")
+        node_text = content.text if content is not None else b""
+    elif node.type == "identifier":
+        node_text = node.text
+    else:
+        return None
+    name = node_text.decode("utf-8", errors="replace")
+    return name if _LUA_IDENTIFIER.match(name) else None
+
+
+def _lua_target_path(node: Node | None) -> str | None:
+    """The dotted path of an assignment target, e.g. `t.a.b` for `t["a"]["b"]`.
+
+    Walked iteratively: a generated file can carry a path thousands of segments
+    long, and recursing over one exhausts the stack.
+
+    None for anything that is not a path — a call, a parenthesised expression, a
+    computed key. Such a target has no name a reader would write, and its source
+    text can carry newlines and punctuation into the name index.
+    """
+    segments: list[tuple[str, str]] = []
+    while node is not None and node.type != "identifier":
+        if node.type == "method_index_expression":
+            separator, key = ":", node.child_by_field_name("method")
+        elif node.type in ("dot_index_expression", "bracket_index_expression"):
+            separator, key = ".", node.child_by_field_name("field")
+        else:
+            return None
+        name = _lua_key_name(key)
+        if name is None:
+            return None
+        segments.append((separator, name))
+        node = node.child_by_field_name("table")
+
+    if node is None:
+        return None
+    path = node.text.decode("utf-8", errors="replace")
+    for separator, name in reversed(segments):
+        path += separator + name
+    return path
+
+
+def _lua_enclosing_table(field: Node, depth: int = 0) -> str | None:
+    """The path of the table a literal's field belongs to, when it has one.
+
+    `local encode = { ["Entity"] = function() end }` gives `encode`, so that two
+    tables holding the same key do not collapse onto one qualified name. A table
+    nested in another field answers with that field's own path, which is where
+    the depth limit comes in — a path deeper than this says nothing useful.
+    """
+    if depth > 16:
+        return None
+    table = field.parent
+    if table is None or table.type != "table_constructor":
+        return None
+
+    holder = table.parent
+    if holder is None:
+        return None
+
+    if holder.type == "field":                       # a table inside a table
+        name = _lua_key_name(holder.child_by_field_name("name"))
+        if name is None:
+            return None
+        outer = _lua_enclosing_table(holder, depth + 1)
+        return f"{outer}.{name}" if outer else name
+
+    if holder.type != "expression_list":
+        return None
+    assignment = holder.parent
+    if assignment is None or assignment.type != "assignment_statement":
+        return None
+
+    # `local P, Q = {…}, {…}` — the table's own position picks its name.
+    values = list(holder.named_children)
+    variables = next(
+        (c for c in assignment.named_children if c.type == "variable_list"), None,
+    )
+    if variables is None or table not in values:
+        return None
+    position = values.index(table)
+    targets = list(variables.named_children)
+    if position >= len(targets):
+        return None
+    return _lua_target_path(targets[position])
+
+
+def _lua_parameters(node: Node) -> Node | None:
+    """The parameter list of the function a Lua definition node defines.
+
+    The route is spelled out per shape rather than searched: a general descent
+    finds whichever function comes first in the tree, which for an assignment
+    is the one in the *target* if any (`(function(a) end)().x = function(b) end`
+    gives `a`), and on a long dotted path it recurses deep enough to exhaust
+    the stack — losing not just the symbol but every symbol in the file.
+    """
+    params = node.child_by_field_name("parameters")
+    if params is not None:                       # function f(a) / function(a)
+        return params
+
+    if node.type == "variable_declaration":      # local f = function(a)
+        inner = node.named_children[0] if node.named_children else None
+        return _lua_parameters(inner) if inner is not None else None
+
+    if node.type == "assignment_statement":      # T.f = function(a)
+        for child in node.named_children:
+            if child.type == "expression_list":
+                value = child.child_by_field_name("value")
+                return _lua_parameters(value) if value is not None else None
+        return None
+
+    if node.type == "field":                     # { f = function(a) }
+        value = node.child_by_field_name("value")
+        return _lua_parameters(value) if value is not None else None
+
     return None
 
 
@@ -294,6 +492,10 @@ def _kind_from_capture(capture_name: str) -> str:
         "define": "macro",
         "proto": "prototype",
         "qproto": "prototype",
+        "ptrfn": "function",   # C/C++ pointer return types
+        "ptrfn2": "function",
+        "ptrproto": "prototype",
+        "ptrproto2": "prototype",
         "trait": "trait",
         "impl": "impl",
         "template": "template",
@@ -368,6 +570,10 @@ def _build_qualified_name(symbol_name: str | None, node: Node, lang: str) -> str
         if scopes:
             return ".".join(scopes + [symbol_name])
         return symbol_name
+    elif lang == "lua":
+        # The table a function hangs off is written on the definition itself,
+        # not in an enclosing scope node the way a class body is.
+        return _lua_definition_path(node) or symbol_name
     else:
         scopes = _get_enclosing_scope(node)
         if scopes:
@@ -727,6 +933,16 @@ class Indexer:
             # For templates without a name, extract from the inner declaration
             if symbol_name is None and kind == "template":
                 symbol_name = _extract_template_name(def_node)
+
+            # Error recovery inserts MISSING nodes whose text is empty, and a
+            # path left dangling by one — `M. = function() end` — ends on its
+            # separator. An empty name is not NULL, so it would slip past every
+            # IS NOT NULL filter and reach the name index.
+            if symbol_name == "" or (symbol_name or "").endswith((".", ":")):
+                continue
+
+            if lang == "lua" and _lua_nameless_definition(def_node):
+                continue
 
             raw_symbols.append((def_node, kind, symbol_name))
 

--- a/src/srclight/languages.py
+++ b/src/srclight/languages.py
@@ -44,6 +44,18 @@ _C_QUERY = """
     declarator: (function_declarator
         declarator: (identifier) @fn.name)) @fn.def
 
+; A `T*` return type wraps the declarator in a pointer_declarator, `T**` nests two.
+(function_definition
+    declarator: (pointer_declarator
+        declarator: (function_declarator
+            declarator: (identifier) @ptrfn.name))) @ptrfn.def
+
+(function_definition
+    declarator: (pointer_declarator
+        declarator: (pointer_declarator
+            declarator: (function_declarator
+                declarator: (identifier) @ptrfn2.name)))) @ptrfn2.def
+
 (struct_specifier
     name: (type_identifier) @struct.name) @struct.def
 
@@ -53,6 +65,17 @@ _C_QUERY = """
 (declaration
     declarator: (function_declarator
         declarator: (identifier) @proto.name)) @proto.def
+
+(declaration
+    declarator: (pointer_declarator
+        declarator: (function_declarator
+            declarator: (identifier) @ptrproto.name))) @ptrproto.def
+
+(declaration
+    declarator: (pointer_declarator
+        declarator: (pointer_declarator
+            declarator: (function_declarator
+                declarator: (identifier) @ptrproto2.name)))) @ptrproto2.def
 
 (type_definition
     declarator: (type_identifier) @typedef.name) @typedef.def
@@ -72,6 +95,23 @@ _CPP_QUERY = """
 (function_definition
     declarator: (function_declarator
         declarator: (qualified_identifier) @method.name)) @method.def
+
+; A `T*` return type wraps the declarator in a pointer_declarator, `T**` nests two.
+(function_definition
+    declarator: (pointer_declarator
+        declarator: (function_declarator
+            declarator: (identifier) @ptrfn.name))) @ptrfn.def
+
+(function_definition
+    declarator: (pointer_declarator
+        declarator: (pointer_declarator
+            declarator: (function_declarator
+                declarator: (identifier) @ptrfn2.name)))) @ptrfn2.def
+
+(declaration
+    declarator: (pointer_declarator
+        declarator: (function_declarator
+            declarator: (identifier) @ptrproto.name))) @ptrproto.def
 
 (class_specifier
     name: (type_identifier) @cls.name) @cls.def
@@ -341,6 +381,86 @@ _GROOVY_QUERY = """
     (identifier) @fn.name) @fn.def
 """
 
+# Lua has no declaration keyword for tables, so a "class" is a table a function
+# hangs off. `function T.f()` and `T.f = function()` are the same definition
+# written two ways, and both are captured.
+#
+# The symbol name is whatever a call site writes. `T.f()` is written in full, so
+# the dotted path is the name; `T:f()` never is — a method is called on an
+# instance, `obj:f()` — so there the name is `f` alone, and the path is kept as
+# the qualified name. Same for `t["f"]`, which no call site spells that way.
+_LUA_QUERY = """
+(function_declaration
+    name: (identifier) @fn.name) @fn.def
+
+(function_declaration
+    name: (dot_index_expression) @fn.name) @fn.def
+
+(function_declaration
+    name: (method_index_expression
+        method: (identifier) @method.name)) @method.def
+
+; `T.f = function()` as a statement. The anchors pin one name to one value:
+; without them `local n, f = 0, function() end` captures `n` as a function too,
+; since the pattern only asks that *some* value in the list be a function. A
+; multi-assignment is therefore skipped whole — a miss beats a symbol that
+; claims a number is a function. For the same reason the value must *be* a
+; function rather than contain one, so the define-once idiom `M.f = M.f or
+; function() end` is missed: matching any expression containing a function
+; would make `M.f = wrap(function() end)` a definition of `M.f` too.
+;
+; chunk and block are spelled out rather than matched with a wildcard parent:
+; the third parent an assignment can have is variable_declaration, and that one
+; needs the pattern below, which would otherwise capture the same node twice.
+(chunk
+    (assignment_statement
+        (variable_list . name: [(identifier) (dot_index_expression)] @fn.name .)
+        (expression_list . value: (function_definition) .)) @fn.def)
+
+(block
+    (assignment_statement
+        (variable_list . name: [(identifier) (dot_index_expression)] @fn.name .)
+        (expression_list . value: (function_definition) .)) @fn.def)
+
+; `t["f"] = function()`. Only a string key defines a name; `t[k] = function()`
+; names nothing, since `k` is a variable holding the key rather than the key.
+(chunk
+    (assignment_statement
+        (variable_list
+            . name: (bracket_index_expression
+                field: (string (string_content) @fn.name)) .)
+        (expression_list . value: (function_definition) .)) @fn.def)
+
+(block
+    (assignment_statement
+        (variable_list
+            . name: (bracket_index_expression
+                field: (string (string_content) @fn.name)) .)
+        (expression_list . value: (function_definition) .)) @fn.def)
+
+; `local f = function()`. The wrapper is the symbol, not the assignment inside
+; it: the `local` keyword and the doc comment above it both live out there.
+(variable_declaration
+    (assignment_statement
+        (variable_list . name: (identifier) @fn.name (attribute)? .)
+        (expression_list . value: (function_definition) .))) @fn.def
+
+; A function hung off a table literal — `local M = { f = function() end }`.
+; A key written `["f"]` is the same definition, so the name comes from inside
+; the string: `f`, not `"f"`, to match what the identifier form yields.
+;
+; The grammar gives `f = ...` and `[f] = ...` the same `name:` field, and a
+; query cannot ask for the absence of the brackets, so the computed-key form is
+; rejected in the indexer instead — see _lua_nameless_definition.
+(field
+    name: (identifier) @fn.name
+    value: (function_definition)) @fn.def
+
+(field
+    name: (string (string_content) @fn.name)
+    value: (function_definition)) @fn.def
+"""
+
 
 LANGUAGES: dict[str, LanguageConfig] = {
     "python": LanguageConfig(
@@ -450,6 +570,12 @@ LANGUAGES: dict[str, LanguageConfig] = {
         extensions=(".groovy", ".gradle"),
         loader="tree_sitter_groovy",
         symbol_query=_GROOVY_QUERY,
+    ),
+    "lua": LanguageConfig(
+        name="lua",
+        extensions=(".lua",),
+        loader="tree_sitter_lua",
+        symbol_query=_LUA_QUERY,
     ),
 }
 

--- a/src/srclight/refmask.py
+++ b/src/srclight/refmask.py
@@ -18,12 +18,46 @@ __all__ = ["mask_noncode"]
 _HASH_LANGS = {"python", "shell", "bash", "ruby", "yaml", "toml", "perl"}
 _SLASH_LANGS = {"c", "cpp", "js", "javascript", "ts", "typescript", "java", "go",
                 "rust", "dart", "swift", "csharp", "c_sharp", "kotlin", "scala", "php"}
+# `--` comments. Lua needs its own tier because `#` measures a table there and
+# `//` divides, so the generic one — which allows both — blanks live code.
+_DASH_LANGS = {"lua"}
 
 
-def mask_noncode(content: str, language: str) -> str:
+def _long_bracket_end(content: str, i: int) -> int | None:
+    """End offset of the Lua long bracket opening at `i` (`[[`, `[=[`, ...).
+
+    Returns None when no bracket opens there — `t[1]` must stay code.
+    """
+    if i >= len(content) or content[i] != "[":
+        return None
+    j = i + 1
+    while j < len(content) and content[j] == "=":
+        j += 1
+    if j >= len(content) or content[j] != "[":
+        return None
+    close = "]" + "=" * (j - i - 1) + "]"
+    end = content.find(close, j + 1)
+    return len(content) if end == -1 else end + len(close)
+
+
+def mask_noncode(content: str, language: str, *, mask_strings: bool = True) -> str:
+    """Blank comments and strings, keeping every offset.
+
+    Pass mask_strings=False to blank comments only. Strings are still scanned —
+    a `--` inside one is not a comment — but their content survives, which is
+    what a caller needs when the thing it looks for lives in a string. In that
+    mode an unbalanced quote leaves the rest of the input unscanned, so it suits
+    a language where one cannot occur outside a string, not prose.
+    """
     lang = (language or "").lower()
-    use_hash = lang in _HASH_LANGS or lang not in _SLASH_LANGS   # generic: allow # too
-    use_slash = lang in _SLASH_LANGS or lang not in _HASH_LANGS  # generic: allow // too
+    generic = lang not in _SLASH_LANGS and lang not in _HASH_LANGS and lang not in _DASH_LANGS
+    use_hash = lang in _HASH_LANGS or generic                    # generic: allow # too
+    use_slash = lang in _SLASH_LANGS or generic                  # generic: allow // too
+    use_dash = lang in _DASH_LANGS
+    # Long brackets are Lua's alone, and stay tied to the language rather than
+    # to the `--` tier: elsewhere `[[` is a nested index, and reading it as a
+    # string opener blanks the rest of the body when no `]]` ever follows.
+    use_long_brackets = lang == "lua"
     hash_is_directive = lang in ("c", "cpp")                     # keep #include lines
 
     out = list(content)
@@ -42,15 +76,34 @@ def mask_noncode(content: str, language: str) -> str:
             q = content[i:i + 3]
             end = content.find(q, i + 3)
             end = n if end == -1 else end + 3
+            if mask_strings:
+                blank(i, end)
+            i = end
+            continue
+        # `-- to end of line`, or in lua `--[[ ... ]]` spanning lines
+        if use_dash and two == "--":
+            end = _long_bracket_end(content, i + 2) if use_long_brackets else None
+            if end is None:
+                end = content.find("\n", i)
+                end = n if end == -1 else end
             blank(i, end)
             i = end
             continue
+        # lua long strings: [[ ... ]], [=[ ... ]=]
+        if use_long_brackets and ch == "[":
+            end = _long_bracket_end(content, i)
+            if end is not None:
+                if mask_strings:
+                    blank(i, end)
+                i = end
+                continue
         if ch in ("'", '"'):
             j = i + 1
             while j < n and content[j] != ch:
                 j += 2 if content[j] == "\\" else 1
             j = min(j + 1, n)
-            blank(i, j)
+            if mask_strings:
+                blank(i, j)
             i = j
             continue
         if use_slash and two == "//":

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -124,6 +124,37 @@ def test_symbols_in_file(db):
     assert [s.name for s in syms] == ["foo", "bar", "baz"]
 
 
+def test_get_symbol_by_name_prefers_definition(db):
+    """A name shared by a prototype and a definition resolves to the definition.
+
+    Edges hang off the definition, so returning the prototype leaves callers
+    and callees empty.
+    """
+    file_id = db.upsert_file(FileRecord(
+        path="src/lib.c", content_hash="abc",
+        mtime=1000.0, language="c", size=100, line_count=20,
+    ))
+
+    # Prototype first, so an unordered LIMIT 1 would return it.
+    db.insert_symbol(SymbolRecord(
+        file_id=file_id, kind="prototype", name="node_create",
+        start_line=1, end_line=1, content="Node* node_create(int value);", line_count=1,
+    ), "src/lib.c")
+
+    definition_id = db.insert_symbol(SymbolRecord(
+        file_id=file_id, kind="function", name="node_create",
+        start_line=5, end_line=8, content="Node* node_create(int value) { return 0; }",
+        line_count=4,
+    ), "src/lib.c")
+
+    db.commit()
+
+    sym = db.get_symbol_by_name("node_create")
+    assert sym is not None
+    assert sym.id == definition_id
+    assert sym.kind == "function"
+
+
 def test_edges(db):
     """Can insert and query symbol relationships."""
     file_id = db.upsert_file(FileRecord(

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -142,6 +142,74 @@ def test_index_c(db, c_project):
     assert "main" in names
 
 
+@pytest.fixture
+def pointer_return_project(tmp_path):
+    """A C and a C++ file whose functions return pointers."""
+    src = tmp_path / "ptrproject"
+    src.mkdir()
+
+    (src / "alloc.c").write_text('''\
+typedef struct Node {
+    int value;
+} Node;
+
+Node* node_create(int value);
+Node** node_table(void);
+
+Node* node_create(int value) {
+    return 0;
+}
+
+Node** node_table(void) {
+    return 0;
+}
+
+Node* node_clone(Node* node) {
+    return node_create(node->value);
+}
+''')
+
+    (src / "alloc.cpp").write_text('''\
+struct Buffer {
+    int size;
+};
+
+Buffer* buffer_create(int size);
+
+Buffer* buffer_create(int size) {
+    return new Buffer{size};
+}
+''')
+
+    return src
+
+
+def test_index_pointer_returning_functions(db, pointer_return_project):
+    """Indexes C and C++ functions whose return type is a pointer."""
+    config = IndexConfig(root=pointer_return_project)
+    indexer = Indexer(db, config)
+    indexer.index(pointer_return_project)
+
+    c_syms = db.symbols_in_file("alloc.c")
+    assert {"node_create", "node_table", "node_clone"} <= {
+        s.name for s in c_syms if s.kind == "function"
+    }
+    assert {"node_create", "node_table"} <= {
+        s.name for s in c_syms if s.kind == "prototype"
+    }
+
+    cpp_syms = db.symbols_in_file("alloc.cpp")
+    assert "buffer_create" in {s.name for s in cpp_syms if s.kind == "function"}
+    assert "buffer_create" in {s.name for s in cpp_syms if s.kind == "prototype"}
+
+    # node_clone calls node_create, and both return a pointer. The edge exists
+    # only if both captures mapped to a kind: an unmapped one becomes "unknown",
+    # which EDGE_TARGET_KINDS filters out.
+    node_create = db.get_symbol_by_name("node_create")
+    assert node_create is not None
+    assert "node_clone" in [c["symbol"].name for c in db.get_callers(node_create.id)]
+
+
 def test_incremental_index(db, sample_project):
     """Incremental indexing skips unchanged files."""
     config = IndexConfig(root=sample_project)
@@ -540,3 +608,437 @@ def test_index_run_leaves_the_main_db_self_contained(tmp_path, sample_project):
     idx_db.close()
     server.close()
     assert count > 0, "index.db is empty on its own — the WAL was never checkpointed"
+
+
+@pytest.fixture
+def lua_project(tmp_path):
+    """Create a minimal Lua project covering every way to define a function."""
+    src = tmp_path / "luaproject"
+    src.mkdir()
+
+    (src / "stack.lua").write_text('''\
+local Stack = {}
+
+-- Pushes a value onto the stack.
+function Stack.push(self, value)
+    self[#self + 1] = value
+end
+
+function Stack:pop()
+    return table.remove(self)
+end
+
+local function clamp(value, limit)
+    return math.min(value, limit)
+end
+
+Stack.peek = function(self)
+    return self[#self]
+end
+
+local wrap = function(fn)
+    return fn
+end
+
+return Stack
+''')
+    return src
+
+
+def test_index_lua(db, lua_project):
+    """Indexes Lua files and extracts every definition shape."""
+    config = IndexConfig(root=lua_project)
+    indexer = Indexer(db, config)
+    stats = indexer.index(lua_project)
+
+    assert stats.files_scanned == 1
+    assert stats.files_indexed == 1
+    assert stats.errors == 0
+
+    db_stats = db.stats()
+    assert "lua" in db_stats["languages"]
+
+    syms = db.symbols_in_file("stack.lua")
+    names = [s.name for s in syms]
+    kinds = {s.name: s.kind for s in syms}
+
+    # function T.name() — a function hung off a table, kept as a dotted name
+    assert "Stack.push" in names
+    assert kinds["Stack.push"] == "function"
+
+    # function T:name() — implicit self, indexed as a method
+    assert "pop" in names
+    assert kinds["pop"] == "method"
+
+    # local function name()
+    assert "clamp" in names
+    assert kinds["clamp"] == "function"
+
+    # T.name = function()
+    assert "Stack.peek" in names
+    assert kinds["Stack.peek"] == "function"
+
+    # local name = function()
+    assert "wrap" in names
+    assert kinds["wrap"] == "function"
+
+
+def test_lua_signature_stops_before_the_body(db, lua_project):
+    """get_signature must show the parameters, not the whole function."""
+    config = IndexConfig(root=lua_project)
+    Indexer(db, config).index(lua_project)
+
+    syms = {s.name: s for s in db.symbols_in_file("stack.lua")}
+    sig = syms["Stack.push"].signature
+
+    assert sig == "function Stack.push(self, value)"
+
+
+def test_lua_doc_comment_is_captured(db, lua_project):
+    """The `--` comment above a function is its doc comment."""
+    config = IndexConfig(root=lua_project)
+    Indexer(db, config).index(lua_project)
+
+    syms = {s.name: s for s in db.symbols_in_file("stack.lua")}
+
+    assert syms["Stack.push"].doc_comment == "-- Pushes a value onto the stack."
+
+
+@pytest.fixture
+def lua_assignment_project(tmp_path):
+    """A Lua project built out of assignments rather than `function` statements."""
+    src = tmp_path / "luaassign"
+    src.mkdir()
+
+    (src / "module.lua").write_text('''\
+local M = {
+    parse = function(text)
+        return text
+    end,
+    ["decode"] = function(text)
+        return text
+    end,
+}
+
+local handlers = {}
+
+handlers["upload"] = function(payload)
+    return payload
+end
+
+M.mul = function(a, b)
+    return a * b
+end
+
+-- Doubles a number.
+local double = function(x)
+    return x * 2
+end
+
+local count, makeThing = 0, function(n)
+    return n
+end
+
+return M
+''')
+    return src
+
+
+def test_lua_table_constructor_fields_are_indexed(db, lua_assignment_project):
+    """A module written as a table literal still has functions in it."""
+    Indexer(db, IndexConfig(root=lua_assignment_project)).index(lua_assignment_project)
+
+    syms = {s.name: s for s in db.symbols_in_file("module.lua")}
+
+    assert "parse" in syms
+    assert syms["parse"].kind == "function"
+
+
+def test_lua_bracketed_keys_are_indexed(db, lua_assignment_project):
+    """A dispatch table keyed by string holds functions like any other."""
+    Indexer(db, IndexConfig(root=lua_assignment_project)).index(lua_assignment_project)
+
+    syms = {s.name: s for s in db.symbols_in_file("module.lua")}
+
+    # `{ ["decode"] = function() }` — named by its key, like the identifier form
+    assert "decode" in syms
+    assert syms["decode"].kind == "function"
+
+    # `handlers["upload"] = function()` — likewise, and the path is the
+    # qualified name; test_lua_bracket_assignment_is_named_by_its_key pins that.
+    assert "upload" in syms
+    assert syms["upload"].kind == "function"
+
+
+def test_lua_assigned_function_signature_shows_parameters(db, lua_assignment_project):
+    """`T.f = function(a, b)` is a function definition like any other."""
+    Indexer(db, IndexConfig(root=lua_assignment_project)).index(lua_assignment_project)
+
+    syms = {s.name: s for s in db.symbols_in_file("module.lua")}
+
+    assert syms["M.mul"].signature == "M.mul = function(a, b)"
+
+
+def test_lua_local_assigned_function_keeps_local_and_doc_comment(db, lua_assignment_project):
+    """The comment sits above `local`, so the symbol must start there too."""
+    Indexer(db, IndexConfig(root=lua_assignment_project)).index(lua_assignment_project)
+
+    syms = {s.name: s for s in db.symbols_in_file("module.lua")}
+
+    assert syms["double"].doc_comment == "-- Doubles a number."
+    assert syms["double"].content.startswith("local double = function(x)")
+    assert syms["double"].signature == "local double = function(x)"
+
+
+def test_lua_multiple_assignment_does_not_mint_a_function_per_name(db, lua_assignment_project):
+    """`local count, makeThing = 0, function() end` — `count` is a number."""
+    Indexer(db, IndexConfig(root=lua_assignment_project)).index(lua_assignment_project)
+
+    names = [s.name for s in db.symbols_in_file("module.lua")]
+
+    # The statement is skipped whole, so `makeThing` is missed too — the
+    # deliberate trade: a miss is visible, a number typed as a function is not.
+    assert "count" not in names
+
+
+def test_lua_method_is_named_the_way_it_is_called(db, lua_project):
+    """`function T:f()` is invoked on an instance, so `f` is the searchable name."""
+    Indexer(db, IndexConfig(root=lua_project)).index(lua_project)
+
+    syms = {s.name: s for s in db.symbols_in_file("stack.lua")}
+
+    # `Stack:pop()` never appears at a call site — `s:pop()` does.
+    assert "pop" in syms
+    assert syms["pop"].qualified_name == "Stack:pop"
+
+
+def test_lua_bracket_assignment_is_named_by_its_key(db, lua_assignment_project):
+    """`handlers["upload"]` cannot match a call site; `upload` can."""
+    Indexer(db, IndexConfig(root=lua_assignment_project)).index(lua_assignment_project)
+
+    syms = {s.name: s for s in db.symbols_in_file("module.lua")}
+
+    assert "upload" in syms
+    # the path it hangs off; test_lua_bracket_key_qualifies_as_a_dotted_path
+    # pins the shape that path takes
+    assert syms["upload"].qualified_name == "handlers.upload"
+
+
+def test_lua_computed_table_key_is_not_a_definition(db, tmp_path):
+    """`[KEY] = function()` names nothing — KEY is a variable holding the key."""
+    src = tmp_path / "computed"
+    src.mkdir()
+    (src / "d.lua").write_text('''\
+local KEY_UPLOAD = "upload"
+
+local dispatch = {
+    [KEY_UPLOAD] = function(payload)
+        return payload
+    end,
+}
+
+return dispatch
+''')
+    Indexer(db, IndexConfig(root=src)).index(src)
+
+    names = [s.name for s in db.symbols_in_file("d.lua")]
+
+    assert "KEY_UPLOAD" not in names
+
+
+def test_broken_source_yields_no_nameless_symbol(db, tmp_path):
+    """Tree-sitter recovers from a syntax error with a MISSING, empty-text node."""
+    src = tmp_path / "broken"
+    src.mkdir()
+    (src / "b.lua").write_text("a = b = function(k) return k end\n")
+
+    Indexer(db, IndexConfig(root=src)).index(src)
+
+    names = [s.name for s in db.symbols_in_file("b.lua")]
+
+    assert "" not in names
+
+
+def test_lua_table_field_qualified_name_carries_no_quotes(db, lua_assignment_project):
+    """A `["key"]` field is qualified by its table, with the quotes off."""
+    Indexer(db, IndexConfig(root=lua_assignment_project)).index(lua_assignment_project)
+
+    syms = {s.name: s for s in db.symbols_in_file("module.lua")}
+
+    assert syms["decode"].qualified_name == "M.decode"
+
+
+def test_lua_attributed_local_is_indexed(db, tmp_path):
+    """Lua 5.4 attributes sit beside the name — `local f <const> = function()`."""
+    src = tmp_path / "attrib"
+    src.mkdir()
+    (src / "a.lua").write_text("local frozen <const> = function(x)\n    return x\nend\n")
+
+    Indexer(db, IndexConfig(root=src)).index(src)
+
+    names = [s.name for s in db.symbols_in_file("a.lua")]
+
+    assert "frozen" in names
+
+
+def test_lua_deep_path_does_not_lose_the_file(db, tmp_path):
+    """A long dotted path must not exhaust the stack — the whole file is at stake."""
+    src = tmp_path / "deep"
+    src.mkdir()
+    path = "a" + "".join(f".b{i}" for i in range(1500))
+    (src / "deep.lua").write_text(f"{path} = function(x) end\nfunction Survivor() end\n")
+
+    stats = Indexer(db, IndexConfig(root=src)).index(src)
+
+    assert stats.errors == 0
+    assert "Survivor" in [s.name for s in db.symbols_in_file("deep.lua")]
+
+
+def test_lua_signature_takes_the_assigned_function_not_one_in_the_target(db, tmp_path):
+    """The parameters belong to the value being assigned, wherever the target looks."""
+    src = tmp_path / "target"
+    src.mkdir()
+    (src / "t.lua").write_text(
+        "(function(NESTED) return {} end)().x = function(OUTER) end\n"
+    )
+
+    Indexer(db, IndexConfig(root=src)).index(src)
+
+    sigs = [s.signature or "" for s in db.symbols_in_file("t.lua")]
+
+    # The target's own function literal must not end the signature early.
+    assert all(s.endswith("function(OUTER)") for s in sigs), sigs
+
+
+def test_lua_bracket_key_qualifies_as_a_dotted_path(db, lua_assignment_project):
+    """`M["k"]` and `M.k` are the same path — the qualified name says so once."""
+    Indexer(db, IndexConfig(root=lua_assignment_project)).index(lua_assignment_project)
+
+    syms = {s.name: s for s in db.symbols_in_file("module.lua")}
+
+    assert syms["upload"].qualified_name == "handlers.upload"
+
+
+def test_lua_table_field_is_qualified_by_its_table(db, tmp_path):
+    """Two tables can hold the same key; the qualified name must tell them apart."""
+    src = tmp_path / "tables"
+    src.mkdir()
+    (src / "v.lua").write_text('''\
+local encode = {
+    ["Entity"] = function(e) return e end,
+}
+
+local decode = {
+    ["Entity"] = function(s) return s end,
+}
+
+return encode, decode
+''')
+
+    Indexer(db, IndexConfig(root=src)).index(src)
+
+    quals = sorted(s.qualified_name for s in db.symbols_in_file("v.lua"))
+
+    assert quals == ["decode.Entity", "encode.Entity"]
+
+
+def test_lua_malformed_dotted_name_is_dropped(db, tmp_path):
+    """Error recovery leaves a dangling `M.` — a path with no field names nothing."""
+    src = tmp_path / "malformed"
+    src.mkdir()
+    (src / "m.lua").write_text("M. = function() end\n")
+
+    Indexer(db, IndexConfig(root=src)).index(src)
+
+    assert [s.name for s in db.symbols_in_file("m.lua")] == []
+
+
+@pytest.fixture
+def lua_nested_project(tmp_path):
+    """Tables holding tables — the shape a config or a dispatch tree takes."""
+    src = tmp_path / "nested"
+    src.mkdir()
+    (src / "n.lua").write_text('''\
+local A = {
+    x = { go = function(a) return a end },
+    y = { go = function(b) return b end },
+}
+
+local M = {}
+
+M["h"] = { f = function(c) return c end }
+
+t["a"]["b"] = function(d) return d end
+
+local P, Q = { p = function(e) return e end }, { q = function(f) return f end }
+
+return A, M, P, Q
+''')
+    return src
+
+
+def test_lua_nested_table_keeps_the_whole_path(db, lua_nested_project):
+    """A key of a nested table is qualified by every table above it."""
+    Indexer(db, IndexConfig(root=lua_nested_project)).index(lua_nested_project)
+
+    quals = {s.qualified_name for s in db.symbols_in_file("n.lua")}
+
+    assert {"A.x.go", "A.y.go"} <= quals
+
+
+
+
+def test_lua_multi_assignment_of_tables_names_each_one(db, lua_nested_project):
+    """`local P, Q = {...}, {...}` — the second table is not the first."""
+    Indexer(db, IndexConfig(root=lua_nested_project)).index(lua_nested_project)
+
+    quals = {s.qualified_name for s in db.symbols_in_file("n.lua")}
+
+    assert {"P.p", "Q.q"} <= quals
+
+
+def test_lua_bracket_path_qualifies_without_punctuation(db, lua_nested_project):
+    """Every step of a path is written the way it would be read."""
+    Indexer(db, IndexConfig(root=lua_nested_project)).index(lua_nested_project)
+
+    quals = {s.qualified_name for s in db.symbols_in_file("n.lua")}
+
+    assert "M.h.f" in quals    # table reached through ["h"]
+    assert "t.a.b" in quals    # target written ["a"]["b"]
+
+
+def test_lua_unwritable_target_yields_no_punctuation(db, tmp_path):
+    """A target that is not a path — a call, a key with spaces — qualifies plainly."""
+    src = tmp_path / "odd"
+    src.mkdir()
+    (src / "q.lua").write_text(
+        'require("m")\n  .field = function(x) end\n'
+        'local S = { ["a b"] = function(y) end }\n'
+    )
+
+    Indexer(db, IndexConfig(root=src)).index(src)
+
+    for sym in db.symbols_in_file("q.lua"):
+        qn = sym.qualified_name or ""
+        assert "\n" not in qn and '"' not in qn and "[" not in qn, qn
+
+
+def test_lua_key_that_is_no_identifier_still_names_its_function(db, tmp_path):
+    """`t["on-connect"]` cannot join a dotted path, but it does name a function."""
+    src = tmp_path / "dashed"
+    src.mkdir()
+    (src / "k.lua").write_text('''\
+local T = {}
+
+T["my-key"] = function(a) return a end
+
+return T
+''')
+
+    Indexer(db, IndexConfig(root=src)).index(src)
+
+    syms = {s.name: s for s in db.symbols_in_file("k.lua")}
+
+    assert "my-key" in syms
+    # no dotted path exists for it, so the qualified name is the bare key
+    assert syms["my-key"].qualified_name == "my-key"

--- a/tests/test_new_tools.py
+++ b/tests/test_new_tools.py
@@ -333,6 +333,26 @@ class TestExtractImports:
         assert "kotlin.collections.List" in modules
         assert "com.example.Utils" in modules
 
+    def test_lua_require(self):
+        content = 'local json = require("dkjson")\nrequire "socket"'
+        imports = _extract_imports(content, "lua")
+        modules = [i["module"] for i in imports]
+        assert "dkjson" in modules
+        assert "socket" in modules
+
+    def test_lua_include(self):
+        """Hosts that embed Lua often load files with include/AddCSLuaFile."""
+        content = 'include("lib/validate.lua")\nAddCSLuaFile("cl_init.lua")'
+        imports = _extract_imports(content, "lua")
+        modules = [i["module"] for i in imports]
+        assert "lib/validate" in modules
+        assert "cl_init" in modules
+
+    def test_lua_require_needs_a_word_boundary(self):
+        """`myrequire(...)` is somebody else's function, not an import."""
+        imports = _extract_imports('local x = myrequire("dkjson")', "lua")
+        assert imports == []
+
     def test_unsupported_language_returns_empty(self):
         imports = _extract_imports("some content", "markdown")
         assert imports == []
@@ -493,3 +513,58 @@ class TestFindImportsIntegration:
         modules = [i["module"] for i in raw_imports]
         assert "stdio.h" in modules
         assert "mylib.h" in modules
+
+
+class TestLuaCommentImports:
+    """A require inside a comment is not a dependency."""
+
+    def test_commented_out_require_is_not_an_import(self):
+        imports = _extract_imports('-- require("legacy_module")', "lua")
+        assert imports == []
+
+    def test_commented_out_include_is_not_an_import(self):
+        imports = _extract_imports('  -- include("old/path.lua")', "lua")
+        assert imports == []
+
+    def test_block_commented_require_is_not_an_import(self):
+        """`--[[ ... ]]` is how a chunk of Lua is disabled; only line 1 has `--`."""
+        content = '--[[\nrequire("legacy_module")\n]]\nrequire("live_module")'
+        modules = [i["module"] for i in _extract_imports(content, "lua")]
+        assert "legacy_module" not in modules
+        assert "live_module" in modules
+
+    def test_lua_include_module_keeps_the_path_without_the_extension(self):
+        """The edge builder reduces a module by splitting on `.` before `/`,
+        so one that kept its extension would reduce to "lua" and name no file.
+        """
+        content = 'include("lib/validate.lua")'
+        module = _extract_imports(content, "lua")[0]["module"]
+
+        assert module == "lib/validate"
+
+    def test_trailing_comment_require_is_not_an_import(self):
+        """A comment need not start the line to be a comment."""
+        imports = _extract_imports('local x = 1  -- require("legacy_module")', "lua")
+        assert imports == []
+
+    def test_unterminated_block_comment_is_not_a_source_of_imports(self):
+        """Callers pass a truncated head, which cuts the closing `]]` off."""
+        content = '--[[ disabled for now\nrequire("legacy_module")\ninclude("old.lua")'
+        assert _extract_imports(content, "lua") == []
+
+    def test_lua_require_also_drops_the_lua_extension(self):
+        """Whatever `include` does with a path, `require` must do too."""
+        modules = [i["module"] for i in _extract_imports('require("lib/validate.lua")', "lua")]
+        assert modules == ["lib/validate"]
+
+    def test_lua_include_rejects_mismatched_quotes(self):
+        imports = _extract_imports('include(\'mixed.lua")', "lua")
+        assert imports == []
+
+    def test_lua_include_of_a_quoted_path_survives_an_apostrophe(self):
+        modules = [i["module"] for i in _extract_imports('include("it\'s.lua")', "lua")]
+        assert modules == ["it's"]
+
+    def test_a_method_named_require_is_not_an_import(self):
+        """`self.require(...)` belongs to some table, not to the loader."""
+        assert _extract_imports('local m = self.require("notmine")', "lua") == []

--- a/tests/test_refmask.py
+++ b/tests/test_refmask.py
@@ -42,3 +42,52 @@ def test_python_hash_not_treated_as_comment_in_c_include():
     out = mask_noncode('#include "helper.h"\nhelper();\n', "cpp")
     assert "#include" in out                  # preprocessor line survives masking
     assert out.count("helper") >= 1           # the call survives
+
+
+def test_lua_line_comment_masked():
+    src = "local x = helper()  -- calls helper\n"
+    out = mask_noncode(src, "lua")
+    assert "helper()" in out                  # the code call survives
+    assert out.count("helper") == 1           # the comment copy is gone
+    assert len(out) == len(src)
+
+
+def test_lua_block_comment_masked_across_lines():
+    src = "--[[ helper does x\n     and y ]]\nhelper()\n"
+    out = mask_noncode(src, "lua")
+    assert out.count("helper") == 1
+    assert out.count("\n") == src.count("\n")  # newlines preserved
+
+
+def test_lua_long_string_masked():
+    src = "local s = [[helper]]\nhelper()\n"
+    out = mask_noncode(src, "lua")
+    assert out.count("helper") == 1
+
+
+def test_lua_length_operator_is_not_a_comment():
+    """`#` counts a table in Lua — it must not blank the rest of the line."""
+    out = mask_noncode("local n = #items + helper()\n", "lua")
+    assert "helper()" in out
+
+
+def test_lua_floor_division_is_not_a_comment():
+    """`//` divides in Lua — the grammar reads it as an operator, so must we."""
+    out = mask_noncode("local q = total // helper()\n", "lua")
+    assert "helper()" in out
+
+
+def test_long_brackets_stay_inside_lua():
+    """`[[` opens a string in Lua only; elsewhere it is a nested index.
+
+    An unclosed one blanks everything after it, so letting the rule reach
+    another language would erase whole symbol bodies.
+    """
+    out = mask_noncode("SELECT ARRAY[[1,2] FROM t;\nSELECT helper();\n", "sql")
+    assert "helper()" in out
+
+
+def test_lua_long_bracket_with_levels_masked():
+    """`[=[ ]=]` and `--[==[ ]==]` are the same construct at another level."""
+    out = mask_noncode("local s = [==[helper]==]\n--[=[ helper ]=]\nhelper()\n", "lua")
+    assert out.count("helper") == 1


### PR DESCRIPTION
Adds Lua to the indexer: symbol extraction, comment masking, and import
patterns. Written against a real ~5k-symbol Garry's Mod addon, which is where
every measurement below comes from.

Before this, `detect_language` returned `None` for `.lua`, so those files never
entered the file list — `files_scanned` read 4 out of 29 — and nothing was
reported: no error, no skip count.

## 1. Naming, and why it decides whether the call graph works

A table is the only namespace Lua has, so a definition takes more shapes than in
most languages. All of them are captured:

```lua
function f() end                  -- f
function T.f() end                -- T.f
function T:f() end                -- f, qualified T:f
T.f = function() end              -- T.f
t["f"] = function() end           -- f, qualified t.f
local M = { f = function() end }  -- f, qualified M.f
```

A symbol is named the way a call site writes it. `T.f()` is written in full, so
the dotted path is the name. `T:f()` never is — a method is called on an
instance — so there the name is `f` alone and the path becomes the qualified
name. This is not cosmetic: `_build_edges` matches literal names, so naming a
method `T:f` leaves it permanently unreachable. Measured on the addon:

| | methods with an incoming edge |
| --- | --- |
| named `T:f` | 2 / 3370 |
| named `f` | 177 / 3370 |

The qualified name is rebuilt from the target rather than copied out of the
source, so it is always a path a reader would write: `t["a"]["b"]` qualifies as
`t.a.b`, and a table literal's field takes the path of the table holding it,
however deeply nested. Without that last part, the two `["Entity"]` keys of a
serialiser and its deserialiser collapse onto one qualified name — 11 such
collisions in a single file of the addon, now one, which is a genuine
redefinition in two branches of an `if`.

## 2. What is deliberately *not* captured

Every one of these is a miss on purpose, because the alternative is a symbol
that lies:

- `local n, f = 0, function() end` — the assignment patterns are anchored so one
  name binds to one value. Without the anchors, `n` is minted as a function with
  the same span and body hash as `f`.
- `{ [k] = function() end }` — `k` holds the key rather than being it.
- `M.f = M.f or function() end` — matching any expression *containing* a
  function would make `M.f = wrap(function() end)` a definition of `M.f` too.
- A target that is not a path at all, such as `require("m").field` — its source
  text would carry newlines and punctuation into the name index.

A key that cannot join a dotted path still names its function: `t["my-key"]` is
indexed as `my-key`, unqualified.

## 3. Masking

Lua's `--` fell through to the generic tier, which allows both `#` and `//`. In
Lua `#` measures a table and `//` divides, so a line like

```lua
local n = #items + helper()
```

was blanked down to `local n =`, losing every reference in it. Lua now has its
own comment family. `--[[ ]]` comments and `[[ ]]` long strings are masked too,
at any `=` level — and the long-bracket rule is tied to the language, not to the
`--` family: elsewhere `[[` is a nested index, and an unclosed one would blank
the rest of the symbol body.

`mask_noncode` grows a keyword-only `mask_strings` flag (default `True`, so
every existing caller is unaffected) used by import extraction to blank comments
while keeping strings, since the module name lives inside one.

## 4. Imports

`require`, plus the `include`/`AddCSLuaFile` that Garry's Mod uses in its place.
The `.lua` comes off the path because `_imports_for` reduces a module to the
name it ends in by splitting on `.` before `/`, which would otherwise leave
`lua`. Comments are masked before scanning rather than skipped line by line:
`--` need not start the line, `--[[ ]]` spans several, and the caller passes a
truncated 100-line head that can cut the closing `]]` off, leaving a disabled
block to read as live imports.

## 5. Packaging

`tree_sitter_lua` joins `TREE_SITTER_PACKAGES`. Grammars load through
`importlib`, which PyInstaller cannot follow, so a packaged build would
otherwise have indexed Lua files with no symbols and no error. (`bash`, `cmake`,
`sql` and `groovy` are missing from that list too — left alone here.)

## Scope

Lua only. `server.py` is untouched, and `mask_noncode` is byte-identical to
`develop` for every non-Lua language — verified by running both versions side by
side over 20k generated inputs across 12 language names. Three non-additive
lines exist in `src/`, all in `refmask.py`, all inert outside Lua; every other
hunk is an addition behind a `lang == "lua"` guard. No version bump, per
`docs/releasing.md`.

## Testing

33 tests added. Full suite: 383 passed. The 10 failures are pre-existing on
`develop` in this environment (missing `tree_sitter_dart`, Windows file
permissions and URI handling) and reproduce with the branch reverted.