### PR TITLE
feat: remember the embedding model so flag-less runs keep embeddings alive

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,27 +152,52 @@ srclight workspace index -w myworkspace --embed qwen3-embedding
 
 ### Choosing the Model Once
 
-`--embed` only has to be passed once per index. Every later run reuses the
-model the index already holds — including the flag-less `srclight index .`
-run by the git hooks and by the MCP `reindex` tool, which would otherwise
-leave every symbol added after the first run unembedded.
+`--embed` only has to be passed once per index. The index records the model
+and every later run reuses it — including the flag-less `srclight index .`
+the git hooks run on each commit, and the MCP `reindex` tool. Without that,
+every symbol added after the first run stays unembedded until someone
+remembers the flag.
 
 ```bash
-srclight index --embed qwen3-embedding   # first run: picks the model
-srclight index                           # later runs: reuses qwen3-embedding
+srclight index --embed qwen3-embedding   # first run: records the model
+srclight index                           # later runs: reuse it, no flag
 ```
 
-To set a default across projects — including brand new indexes — export the
-environment variable:
+The recorded name is provider-qualified, so the second run reports
+`Embedding model: ollama:qwen3-embedding (from the existing index)`.
+
+For indexes that have **no** model recorded yet, `SRCLIGHT_EMBED_MODEL`
+supplies one:
 
 ```bash
 export SRCLIGHT_EMBED_MODEL=qwen3-embedding
-srclight index                           # embeds with qwen3-embedding
+srclight index                           # a fresh index embeds with it
 ```
 
-Resolution order is `--embed` > `SRCLIGHT_EMBED_MODEL` > the model stored in
-the index. `--no-embed` skips embeddings entirely for one run, whatever the
-other two say; over MCP, `reindex(embed=False)` does the same.
+Resolution order is `--embed` > the model recorded in the index >
+`SRCLIGHT_EMBED_MODEL`. The variable comes last on purpose: it is a default
+for new indexes, never an override. Ahead of the recorded model, exporting
+it once would make the next commit in an unrelated repo re-embed every
+symbol it holds, silently, from a background hook. Switching an existing
+index stays an explicit `--embed`.
+
+Two escape hatches:
+
+```bash
+srclight index --no-embed             # skip embedding for this run only
+srclight index --forget-embed-model   # stop embedding this index for good
+```
+
+`--forget-embed-model` is the off switch for the hooks, whose command line
+is fixed: after it, commits index without ever calling the embedding model,
+until you pass `--embed` again. Over MCP, `reindex(embed=False)` is the
+per-call equivalent of `--no-embed`.
+
+Note that skipping is not free. Reindexing a changed file drops the
+embeddings of the symbols it replaces, and a skipped pass does not put them
+back — semantic coverage decays on exactly the files being edited. Ask
+`embedding_status()` what an index will do: `configured_model` is the model
+the next flag-less run uses, and null means it will not embed.
 
 ### How It Works
 
@@ -411,7 +436,7 @@ Srclight exposes 42 MCP tools organized in seven tiers. The MCP server includes 
 | Tool | What it does |
 |------|-------------|
 | `index_status()` | Index freshness and stats |
-| `reindex(embed=True)` | Trigger incremental re-index; `embed=False` skips the embedding pass |
+| `reindex(embed=True)` | Trigger incremental re-index; `embed=False` skips the embedding pass (and lets semantic coverage decay) |
 | `embedding_health()` | Check if the embedding provider (Ollama, etc.) is reachable |
 | `setup_guide()` | Structured setup instructions for agents and users |
 | `server_stats()` | Server uptime and process info |
@@ -523,7 +548,7 @@ srclight hook install --workspace myworkspace
 srclight hook uninstall
 ```
 
-The hooks run `srclight index` in the background after each commit and branch switch.
+The hooks run `srclight index` in the background after each commit and branch switch. On a repo whose index has a recorded embedding model, that refreshes embeddings too — see [Choosing the Model Once](#choosing-the-model-once) for the off switch.
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,30 @@ srclight index --embed qwen3-embedding
 srclight workspace index -w myworkspace --embed qwen3-embedding
 ```
 
+### Choosing the Model Once
+
+`--embed` only has to be passed once per index. Every later run reuses the
+model the index already holds — including the flag-less `srclight index .`
+run by the git hooks and by the MCP `reindex` tool, which would otherwise
+leave every symbol added after the first run unembedded.
+
+```bash
+srclight index --embed qwen3-embedding   # first run: picks the model
+srclight index                           # later runs: reuses qwen3-embedding
+```
+
+To set a default across projects — including brand new indexes — export the
+environment variable:
+
+```bash
+export SRCLIGHT_EMBED_MODEL=qwen3-embedding
+srclight index                           # embeds with qwen3-embedding
+```
+
+Resolution order is `--embed` > `SRCLIGHT_EMBED_MODEL` > the model stored in
+the index. `--no-embed` skips embeddings entirely for one run, whatever the
+other two say.
+
 ### How It Works
 
 1. Each symbol's name + signature + docstring + content is embedded as a float vector

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ srclight index                           # embeds with qwen3-embedding
 
 Resolution order is `--embed` > `SRCLIGHT_EMBED_MODEL` > the model stored in
 the index. `--no-embed` skips embeddings entirely for one run, whatever the
-other two say.
+other two say; over MCP, `reindex(embed=False)` does the same.
 
 ### How It Works
 
@@ -411,7 +411,7 @@ Srclight exposes 42 MCP tools organized in seven tiers. The MCP server includes 
 | Tool | What it does |
 |------|-------------|
 | `index_status()` | Index freshness and stats |
-| `reindex()` | Trigger incremental re-index |
+| `reindex(embed=True)` | Trigger incremental re-index; `embed=False` skips the embedding pass |
 | `embedding_health()` | Check if the embedding provider (Ollama, etc.) is reachable |
 | `setup_guide()` | Structured setup instructions for agents and users |
 | `server_stats()` | Server uptime and process info |

--- a/README.md
+++ b/README.md
@@ -197,7 +197,9 @@ Note that skipping is not free. Reindexing a changed file drops the
 embeddings of the symbols it replaces, and a skipped pass does not put them
 back — semantic coverage decays on exactly the files being edited. Ask
 `embedding_status()` what an index will do: `configured_model` is the model
-the next flag-less run uses, and null means it will not embed.
+the next flag-less run resolves to — the whole chain, environment variable
+included — and null means it will not embed. Single-repo mode only: in a
+workspace each project records its own, so the field is not reported.
 
 ### How It Works
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -193,16 +193,17 @@ The `project` parameter filters to one repo. Omit it to search all.
 2. The `post-commit` hook fires (background, non-blocking)
 3. `srclight index .` runs with `flock` (prevents concurrent re-indexes)
 4. Changed files are re-parsed (tree-sitter), FTS5 indexes updated
-5. Output logged to `.srclight/reindex.log`
+5. Embeddings are refreshed too, if this index has a recorded model
+6. Output logged to `.srclight/reindex.log`
 
-**Note**: The hook does NOT re-embed. FTS5 search (`search_symbols`, keyword part of `hybrid_search`) is always fresh. Semantic search for new/changed symbols requires a manual embed pass (see below).
+**Note**: step 5 is why `--embed` is passed only once. An index that has never embedded stays keyword-only, and `--forget-embed-model` takes an index back to that state. If the embedding provider is unreachable when the hook fires, the run logs a warning and keeps the parse work: FTS5 search (`search_symbols`, keyword part of `hybrid_search`) is never held hostage to the embedding model.
 
 ### What Happens on Branch Switch
 
 1. `git checkout other-branch` triggers `post-checkout` hook
 2. Only fires on branch checkouts (not file checkouts) and only when HEAD changes
 3. Same background `srclight index .` as post-commit
-4. FTS5 indexes updated for all files that differ between branches
+4. FTS5 indexes updated for all files that differ between branches, and embeddings with them when the index has a recorded model
 
 ### Re-Embedding After Significant Changes
 
@@ -222,7 +223,7 @@ srclight workspace index -w myworkspace -p project-name --embed qwen3-embedding
 
 Embedding is incremental — only symbols whose `body_hash` changed get re-embedded. The `.npy` sidecar is rebuilt automatically after embedding.
 
-`--embed` is only needed the first time: an index that already holds embeddings reuses its own model on every later run, so a bare `srclight index` re-embeds too. Set `SRCLIGHT_EMBED_MODEL` to pick a model for indexes that hold none yet, and pass `--no-embed` to skip embedding for a single run.
+`--embed` is only needed the first time: the index records the model and reuses it on every later run, so a bare `srclight index` re-embeds too. `SRCLIGHT_EMBED_MODEL` picks a model for indexes that have none recorded — it is a default, not an override, so it never silently switches a repo that already embeds. `--no-embed` skips embedding for a single run; `--forget-embed-model` stops this index from embedding until `--embed` is passed again.
 
 ### Automating Embedding Refresh with Cron
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -222,9 +222,11 @@ srclight workspace index -w myworkspace -p project-name --embed qwen3-embedding
 
 Embedding is incremental — only symbols whose `body_hash` changed get re-embedded. The `.npy` sidecar is rebuilt automatically after embedding.
 
+`--embed` is only needed the first time: an index that already holds embeddings reuses its own model on every later run, so a bare `srclight index` re-embeds too. Set `SRCLIGHT_EMBED_MODEL` to pick a model for indexes that hold none yet, and pass `--no-embed` to skip embedding for a single run.
+
 ### Automating Embedding Refresh with Cron
 
-Git hooks keep the FTS5 index fresh on every commit, but they do **not** re-embed — embedding requires calling the embedding model (e.g. Ollama) and would slow down every commit. For teams that rely on `hybrid_search` or `semantic_search`, a nightly cron job keeps embeddings current without manual intervention.
+Git hooks reindex in the background with a bare `srclight index .`, so they re-embed whenever the index already holds a model (or `SRCLIGHT_EMBED_MODEL` is exported to the hook's environment). That covers day-to-day drift. A nightly cron job is still useful to catch repos whose embedding provider was down at commit time, and to install hooks in newly added repos.
 
 ```bash
 # Add to crontab (crontab -e)
@@ -249,10 +251,10 @@ tail -50 /tmp/srclight-embed-cron.log
 | Layer | What triggers it | What it does | Speed |
 |-------|-----------------|--------------|-------|
 | **FTS5 index** | Git hooks (`post-commit`, `post-checkout`) | Re-parses changed files via tree-sitter, updates symbol/edge tables and FTS5 indexes | 1-5s per commit |
-| **Embeddings** | Manual `--embed` or cron | Computes embeddings only for symbols whose `body_hash` changed since last embed | ~1s per 25 symbols |
+| **Embeddings** | Any index run once the model is known (hooks, cron, `--embed`) | Computes embeddings only for symbols whose `body_hash` changed since last embed | ~1s per 25 symbols |
 | **Vector cache** | Automatic after embedding | Rebuilds `.npy` sidecar files for GPU/CPU-resident search | <1s |
 
-The index and embeddings are separate concerns: FTS5 is always current (via hooks), embeddings lag until the next `--embed` pass. `search_symbols` uses FTS5 only (always fresh). `hybrid_search` combines both — if embeddings are stale, the keyword half still returns current results.
+The index and embeddings are separate concerns: FTS5 is always current (via hooks), embeddings lag whenever the provider is unreachable at index time — the run logs a warning and moves on. `search_symbols` uses FTS5 only (always fresh). `hybrid_search` combines both — if embeddings are stale, the keyword half still returns current results.
 
 ## Document Extraction
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -193,7 +193,7 @@ The `project` parameter filters to one repo. Omit it to search all.
 2. The `post-commit` hook fires (background, non-blocking)
 3. `srclight index .` runs with `flock` (prevents concurrent re-indexes)
 4. Changed files are re-parsed (tree-sitter), FTS5 indexes updated
-5. Embeddings are refreshed too, if this index has a recorded model
+5. Embeddings are refreshed too, if this index has a recorded model (or `SRCLIGHT_EMBED_MODEL` reaches the hook and the index has recorded nothing)
 6. Output logged to `.srclight/reindex.log`
 
 **Note**: step 5 is why `--embed` is passed only once. An index that has never embedded stays keyword-only, and `--forget-embed-model` takes an index back to that state. If the embedding provider is unreachable when the hook fires, the run logs a warning and keeps the parse work: FTS5 search (`search_symbols`, keyword part of `hybrid_search`) is never held hostage to the embedding model.
@@ -203,7 +203,7 @@ The `project` parameter filters to one repo. Omit it to search all.
 1. `git checkout other-branch` triggers `post-checkout` hook
 2. Only fires on branch checkouts (not file checkouts) and only when HEAD changes
 3. Same background `srclight index .` as post-commit
-4. FTS5 indexes updated for all files that differ between branches, and embeddings with them when the index has a recorded model
+4. FTS5 indexes updated for all files that differ between branches, and embeddings with them when a model resolves (see post-commit, step 5)
 
 ### Re-Embedding After Significant Changes
 
@@ -227,7 +227,7 @@ Embedding is incremental — only symbols whose `body_hash` changed get re-embed
 
 ### Automating Embedding Refresh with Cron
 
-Git hooks reindex in the background with a bare `srclight index .`, so they re-embed whenever the index already holds a model (or `SRCLIGHT_EMBED_MODEL` is exported to the hook's environment). That covers day-to-day drift. A nightly cron job is still useful to catch repos whose embedding provider was down at commit time, and to install hooks in newly added repos.
+Git hooks reindex in the background with a bare `srclight index .`, so they re-embed whenever a model resolves — the one recorded in the index, or `SRCLIGHT_EMBED_MODEL` if the hook's environment carries it and the index has recorded nothing. `srclight index --forget-embed-model` records a deliberate "off" that outranks the variable. That covers day-to-day drift. A nightly cron job is still useful to catch repos whose embedding provider was down at commit time, and to install hooks in newly added repos.
 
 ```bash
 # Add to crontab (crontab -e)
@@ -255,7 +255,7 @@ tail -50 /tmp/srclight-embed-cron.log
 | **Embeddings** | Any index run once the model is known (hooks, cron, `--embed`) | Computes embeddings only for symbols whose `body_hash` changed since last embed | ~1s per 25 symbols |
 | **Vector cache** | Automatic after embedding | Rebuilds `.npy` sidecar files for GPU/CPU-resident search | <1s |
 
-The index and embeddings are separate concerns: FTS5 is always current (via hooks), embeddings lag whenever the provider is unreachable at index time — the run logs a warning and moves on. `search_symbols` uses FTS5 only (always fresh). `hybrid_search` combines both — if embeddings are stale, the keyword half still returns current results.
+The index and embeddings are separate concerns: FTS5 is always current (via hooks), embeddings lag whenever no model resolves for a run (`--no-embed`, `--forget-embed-model`, or an index that has never embedded) or the provider is unreachable at index time — that last case logs a warning and moves on, keeping the parse work. `search_symbols` uses FTS5 only (always fresh). `hybrid_search` combines both — if embeddings are stale, the keyword half still returns current results.
 
 ## Document Extraction
 

--- a/src/srclight/cli.py
+++ b/src/srclight/cli.py
@@ -111,7 +111,11 @@ def index(path: str, db_path: str | None, embed_model: str | None, no_embed: boo
     db.initialize()
 
     config = IndexConfig(root=root, embed_model=embed_model, disable_embeddings=no_embed)
+    # Resolve once and pin the result: resolving again inside the indexer, after
+    # the file pass, can disagree with what we printed here — a checkout that
+    # drops every embedded file cascade-deletes its embeddings mid-run.
     resolved_model = resolve_embed_model(db, config)
+    config.embed_model = resolved_model
     if resolved_model and not embed_model:
         click.echo(f"Embedding model: {resolved_model} (from the existing index)")
     elif resolved_model:
@@ -426,6 +430,7 @@ def workspace_index(ws_name: str, project: str | None, embed_model: str | None, 
                 root=root, embed_model=embed_model, disable_embeddings=no_embed,
             )
             resolved_model = resolve_embed_model(db, indexer_config)
+            indexer_config.embed_model = resolved_model  # pin it, see index()
             if resolved_model and not embed_model:
                 click.echo(f"    Embedding model: {resolved_model} (from the existing index)")
             indexer = Indexer(db, indexer_config)

--- a/src/srclight/cli.py
+++ b/src/srclight/cli.py
@@ -79,15 +79,20 @@ def main(verbose: bool):
 @click.argument("path", default=".", type=click.Path(exists=True))
 @click.option("--db", "db_path", type=click.Path(), help="Database path (default: .srclight/index.db)")
 @click.option("--embed", "embed_model", type=str, default=None,
-              envvar="SRCLIGHT_EMBED_MODEL", show_envvar=True,
-              help="Embedding model (e.g., qwen3-embedding, voyage-code-3). "
-                   "Defaults to the model the index already uses.")
+              help="Embedding model (e.g., qwen3-embedding, voyage-code-3). Passed once: "
+                   "later runs reuse the model recorded in the index, else "
+                   "$SRCLIGHT_EMBED_MODEL.")
 @click.option("--no-embed", is_flag=True, default=False,
-              help="Index without embeddings, ignoring --embed and the stored model")
-def index(path: str, db_path: str | None, embed_model: str | None, no_embed: bool):
+              help="Index without embeddings for this run. Changed files still lose "
+                   "the embeddings of the symbols they replace.")
+@click.option("--forget-embed-model", is_flag=True, default=False,
+              help="Stop embedding this index for good: later runs, git hooks included, "
+                   "leave embeddings alone until --embed is passed again.")
+def index(path: str, db_path: str | None, embed_model: str | None, no_embed: bool,
+          forget_embed_model: bool):
     """Index a codebase for AI-powered search."""
     from .db import Database
-    from .indexer import IndexConfig, Indexer, resolve_embed_model
+    from .indexer import EMBED_MODEL_ENV, IndexConfig, Indexer, resolve_embed_model
 
     root = Path(path).resolve()
     if not root.is_dir():
@@ -110,16 +115,29 @@ def index(path: str, db_path: str | None, embed_model: str | None, no_embed: boo
     db.open()
     db.initialize()
 
-    config = IndexConfig(root=root, embed_model=embed_model, disable_embeddings=no_embed)
+    if forget_embed_model:
+        db.forget_embedding_model()
+        db.commit()
+        click.echo("Embedding model: forgotten — later runs will not embed")
+
+    config = IndexConfig(
+        root=root, embed_model=embed_model,
+        disable_embeddings=no_embed or forget_embed_model,
+    )
     # Resolve once and pin the result: resolving again inside the indexer, after
     # the file pass, can disagree with what we printed here — a checkout that
     # drops every embedded file cascade-deletes its embeddings mid-run.
     resolved_model = resolve_embed_model(db, config)
     config.embed_model = resolved_model
-    if resolved_model and not embed_model:
-        click.echo(f"Embedding model: {resolved_model} (from the existing index)")
-    elif resolved_model:
+    if no_embed:
+        click.echo("Embeddings: skipped (--no-embed)")
+    elif resolved_model and embed_model:
         click.echo(f"Embedding model: {resolved_model}")
+    elif resolved_model:
+        origin = ("from the existing index"
+                  if resolved_model == db.detect_embedding_model()
+                  else f"from ${EMBED_MODEL_ENV}")
+        click.echo(f"Embedding model: {resolved_model} ({origin})")
 
     indexer = Indexer(db, config)
 
@@ -387,11 +405,12 @@ def workspace_remove(project_name: str, ws_name: str):
 @click.option("--workspace", "-w", "ws_name", required=True, help="Workspace to index")
 @click.option("--project", "-p", help="Index only this project (default: all)")
 @click.option("--embed", "embed_model", type=str, default=None,
-              envvar="SRCLIGHT_EMBED_MODEL", show_envvar=True,
-              help="Embedding model (e.g., qwen3-embedding, voyage-code-3). "
-                   "Defaults to the model each index already uses.")
+              help="Embedding model (e.g., qwen3-embedding, voyage-code-3). Passed once: "
+                   "later runs reuse the model recorded in each index, else "
+                   "$SRCLIGHT_EMBED_MODEL.")
 @click.option("--no-embed", is_flag=True, default=False,
-              help="Index without embeddings, ignoring --embed and the stored model")
+              help="Index without embeddings for this run. Changed files still lose "
+                   "the embeddings of the symbols they replace.")
 def workspace_index(ws_name: str, project: str | None, embed_model: str | None, no_embed: bool):
     """Index all (or one) project in a workspace."""
     from .db import Database
@@ -739,6 +758,9 @@ def hook_install(ws_name: str | None):
     - post-checkout: reindex when switching branches
 
     Both run in the background and only re-parse changed files (incremental).
+    On an index that has a recorded embedding model they also refresh
+    embeddings, which calls that model — `srclight index --forget-embed-model`
+    turns that off for a repo.
 
     Without --workspace, installs in the current repo.
     With --workspace, installs across all repos in the workspace.

--- a/src/srclight/cli.py
+++ b/src/srclight/cli.py
@@ -130,7 +130,10 @@ def index(path: str, db_path: str | None, embed_model: str | None, no_embed: boo
     resolved_model = resolve_embed_model(db, config)
     config.embed_model = resolved_model
     if no_embed:
-        click.echo("Embeddings: skipped (--no-embed)")
+        if embed_model:
+            click.echo(f"Embeddings: skipped (--no-embed); --embed {embed_model} ignored")
+        else:
+            click.echo("Embeddings: skipped (--no-embed)")
     elif resolved_model and embed_model:
         click.echo(f"Embedding model: {resolved_model}")
     elif resolved_model:
@@ -162,6 +165,7 @@ def index(path: str, db_path: str | None, embed_model: str | None, no_embed: boo
 
     if resolved_model:
         emb_stats = db.embedding_stats()
+        click.echo(f"  Embedded now:    {stats.symbols_embedded}")
         click.echo(f"  Embeddings:      {emb_stats['embedded_symbols']}/{emb_stats['total_symbols']}"
                     f" ({emb_stats['coverage_pct']}%)")
 
@@ -418,7 +422,7 @@ def workspace_index(ws_name: str, project: str | None, embed_model: str | None,
                     no_embed: bool, forget_embed_model: bool):
     """Index all (or one) project in a workspace."""
     from .db import Database
-    from .indexer import IndexConfig, Indexer, resolve_embed_model
+    from .indexer import EMBED_MODEL_ENV, IndexConfig, Indexer, resolve_embed_model
     from .workspace import WorkspaceConfig
 
     config = WorkspaceConfig.load(ws_name)
@@ -431,7 +435,10 @@ def workspace_index(ws_name: str, project: str | None, embed_model: str | None,
             sys.exit(1)
 
     if no_embed:
-        click.echo("Embeddings: skipped (--no-embed)")
+        if embed_model:
+            click.echo(f"Embeddings: skipped (--no-embed); --embed {embed_model} ignored")
+        else:
+            click.echo("Embeddings: skipped (--no-embed)")
     elif embed_model:
         click.echo(f"Embedding model: {embed_model}")
 
@@ -463,7 +470,10 @@ def workspace_index(ws_name: str, project: str | None, embed_model: str | None,
             resolved_model = resolve_embed_model(db, indexer_config)
             indexer_config.embed_model = resolved_model  # pin it, see index()
             if resolved_model and not embed_model:
-                click.echo(f"    Embedding model: {resolved_model} (from the existing index)")
+                origin = ("from the existing index"
+                          if resolved_model == db.detect_embedding_model()
+                          else f"from ${EMBED_MODEL_ENV}")
+                click.echo(f"    Embedding model: {resolved_model} ({origin})")
             indexer = Indexer(db, indexer_config)
 
             def on_progress(file: str, current: int, total: int):

--- a/src/srclight/cli.py
+++ b/src/srclight/cli.py
@@ -411,7 +411,11 @@ def workspace_remove(project_name: str, ws_name: str):
 @click.option("--no-embed", is_flag=True, default=False,
               help="Index without embeddings for this run. Changed files still lose "
                    "the embeddings of the symbols they replace.")
-def workspace_index(ws_name: str, project: str | None, embed_model: str | None, no_embed: bool):
+@click.option("--forget-embed-model", is_flag=True, default=False,
+              help="Stop embedding every index in the workspace for good: later runs, "
+                   "git hooks included, leave embeddings alone until --embed is passed again.")
+def workspace_index(ws_name: str, project: str | None, embed_model: str | None,
+                    no_embed: bool, forget_embed_model: bool):
     """Index all (or one) project in a workspace."""
     from .db import Database
     from .indexer import IndexConfig, Indexer, resolve_embed_model
@@ -426,7 +430,9 @@ def workspace_index(ws_name: str, project: str | None, embed_model: str | None, 
             click.echo(f"Project '{project}' not found in workspace '{ws_name}'", err=True)
             sys.exit(1)
 
-    if embed_model and not no_embed:
+    if no_embed:
+        click.echo("Embeddings: skipped (--no-embed)")
+    elif embed_model:
         click.echo(f"Embedding model: {embed_model}")
 
     for entry in entries:
@@ -445,8 +451,14 @@ def workspace_index(ws_name: str, project: str | None, embed_model: str | None, 
             db.open()
             db.initialize()
 
+            if forget_embed_model:
+                db.forget_embedding_model()
+                db.commit()
+                click.echo("    Embedding model: forgotten — later runs will not embed")
+
             indexer_config = IndexConfig(
-                root=root, embed_model=embed_model, disable_embeddings=no_embed,
+                root=root, embed_model=embed_model,
+                disable_embeddings=no_embed or forget_embed_model,
             )
             resolved_model = resolve_embed_model(db, indexer_config)
             indexer_config.embed_model = resolved_model  # pin it, see index()

--- a/src/srclight/cli.py
+++ b/src/srclight/cli.py
@@ -79,11 +79,15 @@ def main(verbose: bool):
 @click.argument("path", default=".", type=click.Path(exists=True))
 @click.option("--db", "db_path", type=click.Path(), help="Database path (default: .srclight/index.db)")
 @click.option("--embed", "embed_model", type=str, default=None,
-              help="Embedding model (e.g., qwen3-embedding, voyage-code-3)")
-def index(path: str, db_path: str | None, embed_model: str | None):
+              envvar="SRCLIGHT_EMBED_MODEL", show_envvar=True,
+              help="Embedding model (e.g., qwen3-embedding, voyage-code-3). "
+                   "Defaults to the model the index already uses.")
+@click.option("--no-embed", is_flag=True, default=False,
+              help="Index without embeddings, ignoring --embed and the stored model")
+def index(path: str, db_path: str | None, embed_model: str | None, no_embed: bool):
     """Index a codebase for AI-powered search."""
     from .db import Database
-    from .indexer import IndexConfig, Indexer
+    from .indexer import IndexConfig, Indexer, resolve_embed_model
 
     root = Path(path).resolve()
     if not root.is_dir():
@@ -101,14 +105,18 @@ def index(path: str, db_path: str | None, embed_model: str | None):
 
     click.echo(f"Indexing {root}")
     click.echo(f"Database: {db_file}")
-    if embed_model:
-        click.echo(f"Embedding model: {embed_model}")
 
     db = Database(db_file)
     db.open()
     db.initialize()
 
-    config = IndexConfig(root=root, embed_model=embed_model)
+    config = IndexConfig(root=root, embed_model=embed_model, disable_embeddings=no_embed)
+    resolved_model = resolve_embed_model(db, config)
+    if resolved_model and not embed_model:
+        click.echo(f"Embedding model: {resolved_model} (from the existing index)")
+    elif resolved_model:
+        click.echo(f"Embedding model: {resolved_model}")
+
     indexer = Indexer(db, config)
 
     def on_progress(file: str, current: int, total: int):
@@ -130,7 +138,7 @@ def index(path: str, db_path: str | None, embed_model: str | None):
     db_stats = db.stats()
     click.echo(f"  Database size:   {db_stats['db_size_mb']} MB")
 
-    if embed_model:
+    if resolved_model:
         emb_stats = db.embedding_stats()
         click.echo(f"  Embeddings:      {emb_stats['embedded_symbols']}/{emb_stats['total_symbols']}"
                     f" ({emb_stats['coverage_pct']}%)")
@@ -375,11 +383,15 @@ def workspace_remove(project_name: str, ws_name: str):
 @click.option("--workspace", "-w", "ws_name", required=True, help="Workspace to index")
 @click.option("--project", "-p", help="Index only this project (default: all)")
 @click.option("--embed", "embed_model", type=str, default=None,
-              help="Embedding model (e.g., qwen3-embedding, voyage-code-3)")
-def workspace_index(ws_name: str, project: str | None, embed_model: str | None):
+              envvar="SRCLIGHT_EMBED_MODEL", show_envvar=True,
+              help="Embedding model (e.g., qwen3-embedding, voyage-code-3). "
+                   "Defaults to the model each index already uses.")
+@click.option("--no-embed", is_flag=True, default=False,
+              help="Index without embeddings, ignoring --embed and the stored model")
+def workspace_index(ws_name: str, project: str | None, embed_model: str | None, no_embed: bool):
     """Index all (or one) project in a workspace."""
     from .db import Database
-    from .indexer import IndexConfig, Indexer
+    from .indexer import IndexConfig, Indexer, resolve_embed_model
     from .workspace import WorkspaceConfig
 
     config = WorkspaceConfig.load(ws_name)
@@ -391,7 +403,7 @@ def workspace_index(ws_name: str, project: str | None, embed_model: str | None):
             click.echo(f"Project '{project}' not found in workspace '{ws_name}'", err=True)
             sys.exit(1)
 
-    if embed_model:
+    if embed_model and not no_embed:
         click.echo(f"Embedding model: {embed_model}")
 
     for entry in entries:
@@ -410,7 +422,12 @@ def workspace_index(ws_name: str, project: str | None, embed_model: str | None):
             db.open()
             db.initialize()
 
-            indexer_config = IndexConfig(root=root, embed_model=embed_model)
+            indexer_config = IndexConfig(
+                root=root, embed_model=embed_model, disable_embeddings=no_embed,
+            )
+            resolved_model = resolve_embed_model(db, indexer_config)
+            if resolved_model and not embed_model:
+                click.echo(f"    Embedding model: {resolved_model} (from the existing index)")
             indexer = Indexer(db, indexer_config)
 
             def on_progress(file: str, current: int, total: int):

--- a/src/srclight/db.py
+++ b/src/srclight/db.py
@@ -1327,14 +1327,40 @@ class Database:
             (model,),
         )
 
+    def forget_embedding_model(self) -> None:
+        """Stop flag-less runs from embedding this index.
+
+        Recorded as an empty choice rather than a deleted row: the row's
+        absence means "never recorded" and falls back to counting existing
+        embeddings, which would resurrect the model this is meant to drop.
+        """
+        self.remember_embedding_model("")
+
+    def bump_embedding_cache_version(self) -> None:
+        """Mark the .npy sidecar stale without touching any embedding.
+
+        A run that skips embedding still deletes and re-creates symbols, and
+        symbol_embeddings cascades with them. Only upsert_embedding bumps the
+        version, so the sidecar kept describing the previous index — and
+        symbols.id is a rowid, reused after deletion, so a stale sidecar
+        serves one symbol's score under another symbol's identity.
+        """
+        assert self.conn is not None
+        self.conn.execute(
+            """INSERT INTO schema_info (key, value) VALUES ('embedding_cache_version', '1')
+               ON CONFLICT(key) DO UPDATE SET value = CAST(CAST(value AS INTEGER) + 1 AS TEXT)""",
+        )
+
     def detect_embedding_model(self) -> str | None:
         """The embedding model this index was built with, if any."""
         assert self.conn is not None
         row = self.conn.execute(
             "SELECT value FROM schema_info WHERE key = 'embed_model'"
         ).fetchone()
-        if row and row["value"]:
-            return row["value"]
+        if row is not None:
+            # Recorded — including recorded as empty, which means the user
+            # asked this index to stop embedding. Authoritative either way.
+            return row["value"] or None
 
         # Indexes embedded before the choice was recorded: infer it from the
         # rows. An index can hold several models (a switch that failed part
@@ -1831,6 +1857,10 @@ class Database:
     def commit(self) -> None:
         assert self.conn is not None
         self.conn.commit()
+
+    def rollback(self) -> None:
+        assert self.conn is not None
+        self.conn.rollback()
 
 
 def content_hash(data: bytes) -> str:

--- a/src/srclight/db.py
+++ b/src/srclight/db.py
@@ -1319,6 +1319,19 @@ class Database:
             })
         return results
 
+    def detect_embedding_model(self) -> str | None:
+        """The embedding model this index was built with, if any.
+
+        An index can hold rows from several models (the user switched); the
+        one covering the most symbols is the one worth continuing with.
+        """
+        assert self.conn is not None
+        row = self.conn.execute(
+            """SELECT model, COUNT(*) AS n FROM symbol_embeddings
+               GROUP BY model ORDER BY n DESC, model ASC LIMIT 1"""
+        ).fetchone()
+        return row["model"] if row else None
+
     def embedding_stats(self) -> dict:
         """Get embedding statistics."""
         assert self.conn is not None

--- a/src/srclight/db.py
+++ b/src/srclight/db.py
@@ -1350,13 +1350,6 @@ class Database:
         ).fetchone()
         return row is not None and not row["value"]
 
-    def has_embeddings(self) -> bool:
-        """Whether this index holds any embedding at all."""
-        assert self.conn is not None
-        return self.conn.execute(
-            "SELECT 1 FROM symbol_embeddings LIMIT 1"
-        ).fetchone() is not None
-
     def bump_embedding_cache_version(self) -> None:
         """Mark the .npy sidecar stale without touching any embedding.
 

--- a/src/srclight/db.py
+++ b/src/srclight/db.py
@@ -1319,13 +1319,26 @@ class Database:
             })
         return results
 
-    def detect_embedding_model(self) -> str | None:
-        """The embedding model this index was built with, if any.
-
-        An index can hold rows from several models (the user switched); the
-        one covering the most symbols is the one worth continuing with.
-        """
+    def remember_embedding_model(self, model: str) -> None:
+        """Record the model this index embeds with, for flag-less runs."""
         assert self.conn is not None
+        self.conn.execute(
+            "INSERT OR REPLACE INTO schema_info (key, value) VALUES ('embed_model', ?)",
+            (model,),
+        )
+
+    def detect_embedding_model(self) -> str | None:
+        """The embedding model this index was built with, if any."""
+        assert self.conn is not None
+        row = self.conn.execute(
+            "SELECT value FROM schema_info WHERE key = 'embed_model'"
+        ).fetchone()
+        if row and row["value"]:
+            return row["value"]
+
+        # Indexes embedded before the choice was recorded: infer it from the
+        # rows. An index can hold several models (a switch that failed part
+        # way through), so the one covering the most symbols wins.
         row = self.conn.execute(
             """SELECT model, COUNT(*) AS n FROM symbol_embeddings
                GROUP BY model ORDER BY n DESC, model ASC LIMIT 1"""

--- a/src/srclight/db.py
+++ b/src/srclight/db.py
@@ -1336,6 +1336,13 @@ class Database:
         """
         self.remember_embedding_model("")
 
+    def has_embeddings(self) -> bool:
+        """Whether this index holds any embedding at all."""
+        assert self.conn is not None
+        return self.conn.execute(
+            "SELECT 1 FROM symbol_embeddings LIMIT 1"
+        ).fetchone() is not None
+
     def bump_embedding_cache_version(self) -> None:
         """Mark the .npy sidecar stale without touching any embedding.
 

--- a/src/srclight/db.py
+++ b/src/srclight/db.py
@@ -1336,6 +1336,20 @@ class Database:
         """
         self.remember_embedding_model("")
 
+    def embedding_model_forgotten(self) -> bool:
+        """Whether this index was explicitly told to stop embedding.
+
+        Distinct from "no model recorded": both make detect_embedding_model
+        return None, but only this one must also outrank SRCLIGHT_EMBED_MODEL
+        — otherwise the off switch does not work for the very user the docs
+        told to export it.
+        """
+        assert self.conn is not None
+        row = self.conn.execute(
+            "SELECT value FROM schema_info WHERE key = 'embed_model'"
+        ).fetchone()
+        return row is not None and not row["value"]
+
     def has_embeddings(self) -> bool:
         """Whether this index holds any embedding at all."""
         assert self.conn is not None

--- a/src/srclight/indexer.py
+++ b/src/srclight/indexer.py
@@ -131,6 +131,7 @@ class IndexStats:
     symbols_extracted: int = 0
     edges_created: int = 0
     errors: int = 0
+    symbols_embedded: int = 0
     elapsed_seconds: float = 0.0
 
 
@@ -148,11 +149,20 @@ class IndexConfig:
 def resolve_embed_model(db: Database, config: IndexConfig) -> str | None:
     """Pick the embedding model for a run.
 
-    Priority: the explicit model (--embed) > SRCLIGHT_EMBED_MODEL > the model
-    the index already holds. That last fallback is what keeps embeddings alive
-    across the flag-less reindexes run by the git hooks and the MCP server —
-    without it, every symbol added after the first `--embed` run stays
-    unembedded. `disable_embeddings` opts out of all three.
+    Priority: the explicit model (--embed) > the model the index already
+    holds > SRCLIGHT_EMBED_MODEL. The middle one is what keeps embeddings
+    alive across the flag-less reindexes run by the git hooks and the MCP
+    server — without it, every symbol added after the first `--embed` run
+    stays unembedded.
+
+    The environment variable comes LAST on purpose: it is a default for
+    indexes that have no model yet, not an override. Ahead of the recorded
+    model, exporting it once — as the README suggests — would make the next
+    commit in an unrelated repo re-embed every symbol it holds, silently,
+    from a detached background hook, against a metered API in the paid case.
+    Switching an existing index stays an explicit `--embed`.
+
+    `disable_embeddings` opts out of all three.
     """
     if config.disable_embeddings:
         return None
@@ -161,11 +171,11 @@ def resolve_embed_model(db: Database, config: IndexConfig) -> str | None:
     if explicit:
         return explicit
 
-    from_env = os.environ.get(EMBED_MODEL_ENV, "").strip()
-    if from_env:
-        return from_env
+    recorded = db.detect_embedding_model()
+    if recorded:
+        return recorded
 
-    return db.detect_embedding_model()
+    return os.environ.get(EMBED_MODEL_ENV, "").strip() or None
 
 
 def _should_ignore(path: Path, root: Path, patterns: list[str]) -> bool:
@@ -667,12 +677,23 @@ class Indexer:
             except Exception:
                 logger.warning("Community detection failed", exc_info=True)
 
+        # Make the file pass durable BEFORE embedding. index() otherwise runs
+        # as one transaction opened at the first file upsert, so the embedding
+        # pass — minutes of HTTP calls — held the write lock the whole time and
+        # took the parse work down with it if it failed. A second writer (the
+        # git hook firing while the MCP server embeds) got 'database is locked'
+        # and lost its own run: no busy_timeout is set.
+        self.db.commit()
+
         # Build embeddings (optional, only if a model is configured or known)
         embed_model = resolve_embed_model(self.db, self.config)
         if embed_model:
-            n_embedded = self._build_embeddings(embed_model)
-            if n_embedded > 0:
-                logger.info("Embedded %d symbols with %s", n_embedded, embed_model)
+            stats.symbols_embedded = self._build_embeddings(embed_model)
+            if stats.symbols_embedded > 0:
+                logger.info("Embedded %d symbols with %s", stats.symbols_embedded, embed_model)
+        elif stats.files_indexed or stats.files_removed:
+            # No embedding pass, but symbols moved under the sidecar's feet.
+            self.db.bump_embedding_cache_version()
 
         # Update index state
         git_head = _get_git_head(root)
@@ -1289,28 +1310,45 @@ class Indexer:
             logger.info("  Embedding batch %d/%d (%.0fs elapsed, ~%.0fs remaining)",
                         batch_num, total, elapsed, remaining)
 
+        # Nothing below may escape this method. Embedding is a best-effort
+        # extra: the index itself is already committed, and every caller —
+        # the CLI, the MCP reindex tool, and above all the git hooks, which
+        # run flag-less on every commit — must survive a provider that is
+        # down, slow, or serving a model that does not exist.
         try:
             results = embed_symbols(provider, symbols, on_progress=_on_progress)
-        except ConnectionError as e:
-            logger.error("Embedding failed: %s", e)
-            return 0
 
-        # Remember what actually embedded, so the next flag-less run continues
-        # with it. Recorded only on success: a typo'd model must not become the
-        # index's choice, and a switch that failed part way through must not be
-        # reverted by the old model's row count.
-        if results:
+            if not results:
+                # embed_symbols swallows per-batch failures and returns [], so
+                # an empty list means the provider is unreachable as often as
+                # it means there was nothing to do. Stop here either way:
+                # provider.dimensions would re-probe the network and raise.
+                logger.warning("Embedded no symbols with %s — provider unreachable?",
+                               provider.name)
+                return 0
+
+            # Remember what actually embedded, so the next flag-less run
+            # continues with it. Recorded only on success: a typo'd model must
+            # not become the index's choice, and a switch that failed part way
+            # through must not be reverted by the old model's row count.
             self.db.remember_embedding_model(provider.name)
 
-        # Store embeddings
-        dims = provider.dimensions
-        for symbol_id, emb_bytes in results:
-            # Find body_hash from the symbols list
-            sym = next((s for s in symbols if s["id"] == symbol_id), None)
-            body_hash = sym["body_hash"] if sym else None
-            self.db.upsert_embedding(symbol_id, provider.name, dims, emb_bytes, body_hash)
+            # Store embeddings
+            dims = provider.dimensions
+            for symbol_id, emb_bytes in results:
+                # Find body_hash from the symbols list
+                sym = next((s for s in symbols if s["id"] == symbol_id), None)
+                body_hash = sym["body_hash"] if sym else None
+                self.db.upsert_embedding(symbol_id, provider.name, dims, emb_bytes, body_hash)
 
-        self.db.commit()
+            self.db.commit()
+        except Exception as e:
+            logger.error("Embedding failed, index left intact: %s", e)
+            try:
+                self.db.rollback()
+            except Exception:
+                logger.debug("Rollback after embedding failure failed", exc_info=True)
+            return 0
 
         # Build .npy sidecar for GPU-resident vector cache
         if results:

--- a/src/srclight/indexer.py
+++ b/src/srclight/indexer.py
@@ -1295,6 +1295,13 @@ class Indexer:
             logger.error("Embedding failed: %s", e)
             return 0
 
+        # Remember what actually embedded, so the next flag-less run continues
+        # with it. Recorded only on success: a typo'd model must not become the
+        # index's choice, and a switch that failed part way through must not be
+        # reverted by the old model's row count.
+        if results:
+            self.db.remember_embedding_model(provider.name)
+
         # Store embeddings
         dims = provider.dimensions
         for symbol_id, emb_bytes in results:

--- a/src/srclight/indexer.py
+++ b/src/srclight/indexer.py
@@ -117,7 +117,7 @@ DEFAULT_IGNORE = [
 # Max file size to index (1 MB)
 MAX_FILE_SIZE = 1_000_000
 
-# Default embedding model, for every run that does not pass --embed
+# Embedding model for indexes that have none recorded — see resolve_embed_model
 EMBED_MODEL_ENV = "SRCLIGHT_EMBED_MODEL"
 
 
@@ -157,9 +157,10 @@ def resolve_embed_model(db: Database, config: IndexConfig) -> str | None:
 
     The environment variable comes LAST on purpose: it is a default for
     indexes that have no model yet, not an override. Ahead of the recorded
-    model, exporting it once — as the README suggests — would make the next
-    commit in an unrelated repo re-embed every symbol it holds, silently,
-    from a detached background hook, against a metered API in the paid case.
+    model, exporting it once — the natural way to set a default — would make
+    the next commit in an unrelated repo re-embed every symbol it holds,
+    silently, from a detached background hook, against a metered API in the
+    paid case.
     Switching an existing index stays an explicit `--embed`.
 
     `disable_embeddings` opts out of all three.

--- a/src/srclight/indexer.py
+++ b/src/srclight/indexer.py
@@ -691,7 +691,7 @@ class Indexer:
             stats.symbols_embedded = self._build_embeddings(embed_model)
             if stats.symbols_embedded > 0:
                 logger.info("Embedded %d symbols with %s", stats.symbols_embedded, embed_model)
-        elif stats.files_indexed or stats.files_removed:
+        elif (stats.files_indexed or stats.files_removed) and self.db.has_embeddings():
             # No embedding pass, but symbols moved under the sidecar's feet.
             self.db.bump_embedding_cache_version()
 

--- a/src/srclight/indexer.py
+++ b/src/srclight/indexer.py
@@ -1644,7 +1644,10 @@ class Indexer:
             if VectorCache(self.config.root / ".srclight").sidecar_exists():
                 self.db.bump_embedding_cache_version()
         except Exception:
-            logger.debug("Could not invalidate the embedding sidecar", exc_info=True)
+            # Not a detail: a sidecar left valid over a changed index serves
+            # one symbol's score under another symbol's identity, because
+            # rowids are reused. Say so at a level people see.
+            logger.warning("Could not invalidate the embedding sidecar", exc_info=True)
 
     def _build_embeddings(self, model_spec: str) -> int:
         """Generate embeddings for symbols that need them.

--- a/src/srclight/indexer.py
+++ b/src/srclight/indexer.py
@@ -176,6 +176,13 @@ def resolve_embed_model(db: Database, config: IndexConfig) -> str | None:
     if recorded:
         return recorded
 
+    # An index told to forget stays off, whatever the environment says. The
+    # docs send users to export the variable and the hooks inherit it, so
+    # letting it win here would leave the one person who most needs the off
+    # switch — the one paying a metered provider on every commit — without one.
+    if db.embedding_model_forgotten():
+        return None
+
     return os.environ.get(EMBED_MODEL_ENV, "").strip() or None
 
 

--- a/src/srclight/indexer.py
+++ b/src/srclight/indexer.py
@@ -10,6 +10,7 @@ import fnmatch
 import hashlib
 import json
 import logging
+import os
 import subprocess
 import time
 from dataclasses import dataclass, field
@@ -116,6 +117,9 @@ DEFAULT_IGNORE = [
 # Max file size to index (1 MB)
 MAX_FILE_SIZE = 1_000_000
 
+# Default embedding model, for every run that does not pass --embed
+EMBED_MODEL_ENV = "SRCLIGHT_EMBED_MODEL"
+
 
 @dataclass
 class IndexStats:
@@ -138,6 +142,30 @@ class IndexConfig:
     max_doc_file_size: int = 50_000_000  # 50 MB for documents (PDF, DOCX, etc.)
     languages: list[str] | None = None  # None = all supported
     embed_model: str | None = None  # e.g. "qwen3-embedding", "voyage-code-3"
+    disable_embeddings: bool = False  # --no-embed: index without touching embeddings
+
+
+def resolve_embed_model(db: Database, config: IndexConfig) -> str | None:
+    """Pick the embedding model for a run.
+
+    Priority: the explicit model (--embed) > SRCLIGHT_EMBED_MODEL > the model
+    the index already holds. That last fallback is what keeps embeddings alive
+    across the flag-less reindexes run by the git hooks and the MCP server —
+    without it, every symbol added after the first `--embed` run stays
+    unembedded. `disable_embeddings` opts out of all three.
+    """
+    if config.disable_embeddings:
+        return None
+
+    explicit = (config.embed_model or "").strip()
+    if explicit:
+        return explicit
+
+    from_env = os.environ.get(EMBED_MODEL_ENV, "").strip()
+    if from_env:
+        return from_env
+
+    return db.detect_embedding_model()
 
 
 def _should_ignore(path: Path, root: Path, patterns: list[str]) -> bool:
@@ -639,11 +667,12 @@ class Indexer:
             except Exception:
                 logger.warning("Community detection failed", exc_info=True)
 
-        # Build embeddings (optional, only if embed_model configured)
-        if self.config.embed_model:
-            n_embedded = self._build_embeddings(self.config.embed_model)
+        # Build embeddings (optional, only if a model is configured or known)
+        embed_model = resolve_embed_model(self.db, self.config)
+        if embed_model:
+            n_embedded = self._build_embeddings(embed_model)
             if n_embedded > 0:
-                logger.info("Embedded %d symbols with %s", n_embedded, self.config.embed_model)
+                logger.info("Embedded %d symbols with %s", n_embedded, embed_model)
 
         # Update index state
         git_head = _get_git_head(root)

--- a/src/srclight/indexer.py
+++ b/src/srclight/indexer.py
@@ -699,9 +699,15 @@ class Indexer:
             stats.symbols_embedded = self._build_embeddings(embed_model)
             if stats.symbols_embedded > 0:
                 logger.info("Embedded %d symbols with %s", stats.symbols_embedded, embed_model)
-        elif (stats.files_indexed or stats.files_removed) and self.db.has_embeddings():
-            # No embedding pass, but symbols moved under the sidecar's feet.
-            self.db.bump_embedding_cache_version()
+
+        # Symbols moved and nothing was embedded: the sidecar now describes a
+        # database that has changed, and symbols.id is a rowid reused after
+        # deletion, so leaving it valid serves one symbol's score under
+        # another symbol's identity. What matters is that the pass wrote
+        # nothing — not why. A configured model whose provider is down, and a
+        # reindex that only removed files, both land here.
+        if (stats.files_indexed or stats.files_removed) and not stats.symbols_embedded:
+            self._invalidate_sidecar()
 
         # Update index state
         git_head = _get_git_head(root)
@@ -1285,6 +1291,21 @@ class Indexer:
 
         return edge_count
 
+    def _invalidate_sidecar(self) -> None:
+        """Mark the .npy sidecar stale, if this index has one to invalidate.
+
+        Keyed on the sidecar's existence rather than on rows in
+        symbol_embeddings: a reindex that removes every embedded file leaves
+        that table empty while the sidecar still lists the deleted symbols.
+        """
+        from .vector_cache import VectorCache
+
+        try:
+            if VectorCache(self.config.root / ".srclight").sidecar_exists():
+                self.db.bump_embedding_cache_version()
+        except Exception:
+            logger.debug("Could not invalidate the embedding sidecar", exc_info=True)
+
     def _build_embeddings(self, model_spec: str) -> int:
         """Generate embeddings for symbols that need them.
 
@@ -1351,7 +1372,9 @@ class Indexer:
 
             self.db.commit()
         except Exception as e:
-            logger.error("Embedding failed, index left intact: %s", e)
+            # exc_info: this catch also covers upsert/commit, so a programming
+            # error must not be reported as one line reading like an outage.
+            logger.error("Embedding failed, index left intact: %s", e, exc_info=True)
             try:
                 self.db.rollback()
             except Exception:

--- a/src/srclight/server.py
+++ b/src/srclight/server.py
@@ -367,6 +367,71 @@ def _get_db() -> Database:
     return _db
 
 
+_vector_cache_rebuild_lock = threading.Lock()
+_vector_cache_rebuild_failed_at: int | None = None
+
+
+def _rebuild_vector_cache(db):
+    """Rebuild the stale sidecar and publish the result.
+
+    Sync MCP tools run on anyio worker threads, so two searches can arrive
+    here at once. Rebuilding is not cheap — a 27K x 4096 index is ~440 MB
+    written and ~1.8 GB peak — and VectorCache._atomic_write uses a fixed
+    temp name, so concurrent builders rename it out from under each other
+    and both fail. One at a time, then.
+
+    Our own mapping has to go before the write, or os.replace hits the same
+    WinError 5 the hook did — so the old cache is invalidated in place, and a
+    thread that is already inside search() with a reference to it sees an
+    empty matrix and returns no hits for that one call. Narrow: a caller
+    reaching search() has just passed is_valid(), which is false from the
+    moment the writer bumped the version, so it must have passed it before
+    that commit landed. Closing the window for good means writing the
+    sidecar under a fresh name so the old mapping never blocks the swap —
+    that is vector_cache._atomic_write's design, not this branch's.
+
+    The rebuilt cache is published by rebinding, so nothing ever observes a
+    half-swapped object. A failure is remembered against the database
+    version that provoked it, so a sidecar this process cannot replace —
+    another long-lived reader holding it mapped — costs one attempt, not one
+    per search forever.
+    """
+    global _vector_cache, _vector_cache_rebuild_failed_at
+
+    from .vector_cache import VectorCache
+
+    srclight_dir = _db_path.parent if _db_path else None
+    if srclight_dir is None:
+        return _vector_cache
+
+    with _vector_cache_rebuild_lock:
+        # Another thread may have rebuilt it while we waited.
+        if _vector_cache is not None and _vector_cache.is_valid(db.conn):
+            return _vector_cache
+
+        version = VectorCache._get_db_version(db.conn)
+        if _vector_cache_rebuild_failed_at == version:
+            return _vector_cache
+
+        logger.info("Vector cache sidecar is stale — rebuilding in-process")
+        stale = _vector_cache
+        fresh = VectorCache(srclight_dir)
+        try:
+            if stale is not None:
+                stale.invalidate()  # drop our mmap so os.replace can land
+            fresh.build_from_db(db.conn)
+        except Exception as e:
+            # Keep serving the stale one: every caller re-checks is_valid and
+            # falls back to the SQLite scan, which is slow but correct.
+            logger.warning("Failed to rebuild vector cache sidecar: %s", e)
+            _vector_cache_rebuild_failed_at = version
+            return _vector_cache
+
+        _vector_cache_rebuild_failed_at = None
+        _vector_cache = fresh
+        return _vector_cache
+
+
 def _get_vector_cache():
     """Get or create the VectorCache (single-repo mode)."""
     global _vector_cache
@@ -384,17 +449,10 @@ def _get_vector_cache():
         # embedding_cache_version it just bumped. Nothing else rebuilds it, so
         # every later semantic_search fell back to a full SQLite scan for the
         # life of the server. We hold the mapping, so we are who can refresh
-        # it: drop ours, then rebuild here.
-        if _vector_cache.is_loaded() and not _vector_cache.is_valid(db.conn):
-            logger.info("Vector cache sidecar is stale — rebuilding in-process")
-            _vector_cache.invalidate()
-            try:
-                _vector_cache.build_from_db(db.conn)
-            except Exception as e:
-                logger.warning("Failed to rebuild vector cache sidecar: %s", e)
-                _vector_cache = None
-                return None
-        return _vector_cache
+        # it.
+        if not (_vector_cache.is_loaded() and not _vector_cache.is_valid(db.conn)):
+            return _vector_cache
+        return _rebuild_vector_cache(db)
 
     srclight_dir = _db_path.parent if _db_path else None
     if srclight_dir is None:
@@ -1313,9 +1371,11 @@ async def reindex(path: str | None = None, embed: bool = True) -> str:
         "symbols_extracted": stats.symbols_extracted,
         "errors": stats.errors,
         "elapsed_seconds": round(stats.elapsed_seconds, 2),
-        # Say what happened to the embeddings: "skipped" is what you asked
-        # for, but 0 embedded on a model that IS configured means the
-        # provider was unreachable, and semantic_search is now behind.
+        # Say what happened to the embeddings. symbols_embedded 0 with a
+        # model configured is ambiguous on purpose — everything was already
+        # embedded, or the provider could not be reached; the run log
+        # distinguishes them. What it does tell you is that semantic_search
+        # sees nothing new from this run.
         "embeddings": {
             "requested": embed,
             "model": config.embed_model,
@@ -3033,11 +3093,14 @@ def _close_databases() -> None:
 
 def configure(db_path: Path | None = None, repo_root: Path | None = None) -> None:
     """Configure the server for single-repo mode."""
-    global _db_path, _repo_root, _db, _vector_cache
+    global _db_path, _repo_root, _db, _vector_cache, _vector_cache_rebuild_failed_at
     if _db is not None:
         _db.close()
         _db = None
     _vector_cache = None
+    # The failure memo is about one database at one version; pointing the
+    # server somewhere else must not carry it over.
+    _vector_cache_rebuild_failed_at = None
     _db_path = db_path
     _repo_root = repo_root
     _refresh_instructions()

--- a/src/srclight/server.py
+++ b/src/srclight/server.py
@@ -1223,7 +1223,7 @@ def list_projects() -> str:
 
 
 @mcp.tool()
-async def reindex(path: str | None = None) -> str:
+async def reindex(path: str | None = None, embed: bool = True) -> str:
     """Trigger re-indexing of the codebase or a specific path.
 
     Incrementally updates the index — only re-parses files whose content
@@ -1231,6 +1231,11 @@ async def reindex(path: str | None = None) -> str:
 
     Args:
         path: Optional specific directory to re-index (default: entire repo)
+        embed: Also refresh embeddings, using the model this index already
+            holds (or SRCLIGHT_EMBED_MODEL). Pass False for a keyword-only
+            refresh when you just need search_symbols current — embedding a
+            large backlog calls the embedding model and can take minutes.
+            Ignored when the index holds no embeddings.
     """
     global _vector_cache
     # `path` is used as an index ROOT, not a filter: Indexer reads the whole
@@ -1262,7 +1267,7 @@ async def reindex(path: str | None = None) -> str:
 
     root = root.resolve()
     db = _get_db()
-    config = IndexConfig(root=root)
+    config = IndexConfig(root=root, disable_embeddings=not embed)
     indexer = Indexer(db, config)
     stats = indexer.index(root)
 

--- a/src/srclight/server.py
+++ b/src/srclight/server.py
@@ -23,7 +23,7 @@ from mcp.server.mcpserver import MCPServer
 
 
 from .db import Database
-from .indexer import IndexConfig, Indexer
+from .indexer import IndexConfig, Indexer, resolve_embed_model
 
 logger = logging.getLogger("srclight.server")
 
@@ -370,12 +370,32 @@ def _get_db() -> Database:
 def _get_vector_cache():
     """Get or create the VectorCache (single-repo mode)."""
     global _vector_cache
-    if _vector_cache is not None:
-        return _vector_cache
 
     from .vector_cache import VectorCache
 
     db = _get_db()
+
+    if _vector_cache is not None:
+        # A flag-less `srclight index` — every git hook run — now embeds, and
+        # it rebuilds the sidecar from its own process. On Windows that
+        # rebuild cannot land: this server holds embeddings.npy mmap'd for its
+        # whole life and os.replace refuses a mapped file, so the hook logs a
+        # warning to reindex.log and leaves a sidecar older than the
+        # embedding_cache_version it just bumped. Nothing else rebuilds it, so
+        # every later semantic_search fell back to a full SQLite scan for the
+        # life of the server. We hold the mapping, so we are who can refresh
+        # it: drop ours, then rebuild here.
+        if _vector_cache.is_loaded() and not _vector_cache.is_valid(db.conn):
+            logger.info("Vector cache sidecar is stale — rebuilding in-process")
+            _vector_cache.invalidate()
+            try:
+                _vector_cache.build_from_db(db.conn)
+            except Exception as e:
+                logger.warning("Failed to rebuild vector cache sidecar: %s", e)
+                _vector_cache = None
+                return None
+        return _vector_cache
+
     srclight_dir = _db_path.parent if _db_path else None
     if srclight_dir is None:
         return None
@@ -1232,11 +1252,14 @@ async def reindex(path: str | None = None, embed: bool = True) -> str:
     Args:
         path: Optional specific directory to re-index (default: entire repo)
         embed: Also refresh embeddings, using the model this index already
-            holds (or SRCLIGHT_EMBED_MODEL, which applies even to an index
-            that holds none yet). Pass False for a keyword-only refresh when
-            you just need search_symbols current — embedding a large backlog
-            calls the embedding model and can take minutes. Does nothing when
-            no model is configured or recorded.
+            holds (or SRCLIGHT_EMBED_MODEL for an index that holds none yet).
+            Pass False for a keyword-only refresh when you only need
+            search_symbols current: embedding a large backlog calls the
+            embedding model and can take minutes. Not free, though — a
+            reindex drops the embeddings of every symbol it replaces, and
+            with embed=False nothing puts them back, so semantic_search and
+            hybrid_search lose coverage on exactly the files being edited.
+            Does nothing when no model is configured or recorded.
     """
     global _vector_cache
     # `path` is used as an index ROOT, not a filter: Indexer reads the whole
@@ -1277,6 +1300,9 @@ async def reindex(path: str | None = None, embed: bool = True) -> str:
     _vector_cache = None
 
     config = IndexConfig(root=root, disable_embeddings=not embed)
+    # Resolve once and pin, as the CLI does: resolving again after the file
+    # pass can disagree with what we report back to the caller.
+    config.embed_model = resolve_embed_model(db, config)
     indexer = Indexer(db, config)
     stats = indexer.index(root)
 
@@ -1287,6 +1313,14 @@ async def reindex(path: str | None = None, embed: bool = True) -> str:
         "symbols_extracted": stats.symbols_extracted,
         "errors": stats.errors,
         "elapsed_seconds": round(stats.elapsed_seconds, 2),
+        # Say what happened to the embeddings: "skipped" is what you asked
+        # for, but 0 embedded on a model that IS configured means the
+        # provider was unreachable, and semantic_search is now behind.
+        "embeddings": {
+            "requested": embed,
+            "model": config.embed_model,
+            "symbols_embedded": stats.symbols_embedded,
+        },
     }
 
     # Send notification to connected clients (MCP logging)
@@ -1649,7 +1683,8 @@ def semantic_search(
     if not emb_stats.get("model"):
         return json.dumps({
             "error": "No embeddings found. Run 'srclight index --embed <model>' first.",
-            "hint": "Try: srclight index --embed qwen3-embedding",
+            "hint": "Try: srclight index --embed qwen3-embedding — once; the index "
+                    "records the model and later runs reuse it",
         })
 
     model_name = emb_stats["model"]
@@ -1791,9 +1826,15 @@ def embedding_status(project: str | None = None) -> str:
     else:
         db = _get_db()
         stats = db.embedding_stats()
+        # stats["model"] comes from an arbitrary embedding row, so after a
+        # model switch it can name the old one. This is the model a flag-less
+        # run — every git hook, and reindex() — will actually use; null means
+        # such a run leaves embeddings alone.
+        stats["configured_model"] = db.detect_embedding_model()
 
     if not stats.get("model"):
-        stats["hint"] = "Run 'srclight index --embed <model>' to generate embeddings"
+        stats["hint"] = ("Run 'srclight index --embed <model>' once to generate embeddings; "
+                         "later runs reuse the model recorded in the index")
 
     return json.dumps(stats, indent=2)
 
@@ -2402,7 +2443,10 @@ async def setup_guide() -> str:
                     "srclight workspace index -w WORKSPACE_NAME",
                     "srclight workspace index -w WORKSPACE_NAME --embed qwen3-embedding",
                 ],
-                "notes": "Ollama on localhost:11434 for qwen3-embedding. Server hot-reloads; no restart needed after indexing.",
+                "notes": "Ollama on localhost:11434 for qwen3-embedding. --embed is passed once: "
+                         "each index records its model and reuses it on every later run, git hooks "
+                         "included (srclight index --forget-embed-model turns that off). Server "
+                         "hot-reloads; no restart needed after indexing.",
             },
             {
                 "step": 3,

--- a/src/srclight/server.py
+++ b/src/srclight/server.py
@@ -1683,8 +1683,7 @@ def semantic_search(
     if not emb_stats.get("model"):
         return json.dumps({
             "error": "No embeddings found. Run 'srclight index --embed <model>' first.",
-            "hint": "Try: srclight index --embed qwen3-embedding — once; the index "
-                    "records the model and later runs reuse it",
+            "hint": "Try: srclight index --embed qwen3-embedding",
         })
 
     model_name = emb_stats["model"]
@@ -1817,6 +1816,13 @@ def embedding_status(project: str | None = None) -> str:
     Shows how many symbols have embeddings, which model was used,
     and the coverage percentage.
 
+    In single-repo mode the result also carries `configured_model`: the model
+    the next flag-less run (a git hook, or reindex()) will actually use, null
+    meaning it will not embed. `model` differs — it names a model already
+    present in the rows, which after a switch can be one no run will use
+    again. Workspace mode does not report `configured_model`: each project
+    records its own, and they need not agree.
+
     Args:
         project: Project name (workspace mode) or uses current repo
     """
@@ -1829,12 +1835,13 @@ def embedding_status(project: str | None = None) -> str:
         # stats["model"] comes from an arbitrary embedding row, so after a
         # model switch it can name the old one. This is the model a flag-less
         # run — every git hook, and reindex() — will actually use; null means
-        # such a run leaves embeddings alone.
-        stats["configured_model"] = db.detect_embedding_model()
+        # such a run leaves embeddings alone. Resolved, not just read back:
+        # SRCLIGHT_EMBED_MODEL is the third leg of the same chain, and an
+        # index with no record still embeds when it is exported.
+        stats["configured_model"] = resolve_embed_model(db, IndexConfig())
 
     if not stats.get("model"):
-        stats["hint"] = ("Run 'srclight index --embed <model>' once to generate embeddings; "
-                         "later runs reuse the model recorded in the index")
+        stats["hint"] = "Run 'srclight index --embed <model>' to generate embeddings"
 
     return json.dumps(stats, indent=2)
 

--- a/src/srclight/server.py
+++ b/src/srclight/server.py
@@ -369,6 +369,10 @@ def _get_db() -> Database:
 
 _vector_cache_rebuild_lock = threading.Lock()
 _vector_cache_rebuild_failed_at: int | None = None
+# True from the moment a rebuild releases our mmap until it has finished.
+# Read without the lock on purpose: a reader must not queue behind a
+# multi-second build just to learn it should not touch the file.
+_vector_cache_rebuilding = False
 
 
 def _rebuild_vector_cache(db):
@@ -396,7 +400,7 @@ def _rebuild_vector_cache(db):
     another long-lived reader holding it mapped — costs one attempt, not one
     per search forever.
     """
-    global _vector_cache, _vector_cache_rebuild_failed_at
+    global _vector_cache, _vector_cache_rebuild_failed_at, _vector_cache_rebuilding
 
     from .vector_cache import VectorCache
 
@@ -417,6 +421,10 @@ def _rebuild_vector_cache(db):
         stale = _vector_cache
         fresh = VectorCache(srclight_dir)
         try:
+            # Announce before releasing: from here to the end of the build,
+            # a reader finding an unloaded cache must leave the file alone
+            # rather than mapping it again — see _get_vector_cache.
+            _vector_cache_rebuilding = True
             if stale is not None:
                 stale.invalidate()  # drop our mmap so os.replace can land
             fresh.build_from_db(db.conn)
@@ -428,6 +436,8 @@ def _rebuild_vector_cache(db):
             _vector_cache_rebuild_failed_at = version
             _vector_cache = None
             return None
+        finally:
+            _vector_cache_rebuilding = False
 
         if not fresh.is_loaded():
             # build_from_db returns without loading anything when the index
@@ -464,11 +474,16 @@ def _get_vector_cache():
         # life of the server. We hold the mapping, so we are who can refresh
         # it.
         if not _vector_cache.is_loaded():
-            # Empty, not finished: a rebuild dropped our mmap and then could
-            # not write, or there was nothing to build from. Never terminal —
-            # fall through to the cold path and read the disk again, or the
-            # server would serve the SQLite scan for the rest of its life
-            # even once a perfectly good sidecar appears.
+            if _vector_cache_rebuilding:
+                # A rebuild released this mapping deliberately and is about to
+                # replace the file. Re-reading it now is what makes os.replace
+                # fail on Windows, so take the SQLite scan for this one call.
+                return _vector_cache
+            # Empty and nobody is rebuilding: a rebuild dropped our mmap and
+            # then could not write, or there was nothing to build from. Never
+            # terminal — fall through to the cold path and read the disk
+            # again, or the server would serve the SQLite scan for the rest of
+            # its life even once a perfectly good sidecar appears.
             _vector_cache = None
         elif not _vector_cache.is_valid(db.conn):
             return _rebuild_vector_cache(db)

--- a/src/srclight/server.py
+++ b/src/srclight/server.py
@@ -421,11 +421,24 @@ def _rebuild_vector_cache(db):
                 stale.invalidate()  # drop our mmap so os.replace can land
             fresh.build_from_db(db.conn)
         except Exception as e:
-            # Keep serving the stale one: every caller re-checks is_valid and
-            # falls back to the SQLite scan, which is slow but correct.
+            # Our mmap is already gone, so there is nothing left to serve from
+            # memory. Callers re-check is_valid and take the SQLite scan —
+            # slow but correct — and the next call reloads from disk.
             logger.warning("Failed to rebuild vector cache sidecar: %s", e)
             _vector_cache_rebuild_failed_at = version
-            return _vector_cache
+            _vector_cache = None
+            return None
+
+        if not fresh.is_loaded():
+            # build_from_db returns without loading anything when the index
+            # holds no embeddings at all — a reindex that removed the last
+            # embedded file. Publishing that would be publishing a dead
+            # cache; the sidecar still on disk describes deleted symbols, so
+            # leave it invalid and let the scan answer until embeddings
+            # return.
+            _vector_cache_rebuild_failed_at = version
+            _vector_cache = None
+            return None
 
         _vector_cache_rebuild_failed_at = None
         _vector_cache = fresh
@@ -450,9 +463,17 @@ def _get_vector_cache():
         # every later semantic_search fell back to a full SQLite scan for the
         # life of the server. We hold the mapping, so we are who can refresh
         # it.
-        if not (_vector_cache.is_loaded() and not _vector_cache.is_valid(db.conn)):
+        if not _vector_cache.is_loaded():
+            # Empty, not finished: a rebuild dropped our mmap and then could
+            # not write, or there was nothing to build from. Never terminal —
+            # fall through to the cold path and read the disk again, or the
+            # server would serve the SQLite scan for the rest of its life
+            # even once a perfectly good sidecar appears.
+            _vector_cache = None
+        elif not _vector_cache.is_valid(db.conn):
+            return _rebuild_vector_cache(db)
+        else:
             return _vector_cache
-        return _rebuild_vector_cache(db)
 
     srclight_dir = _db_path.parent if _db_path else None
     if srclight_dir is None:

--- a/src/srclight/server.py
+++ b/src/srclight/server.py
@@ -1232,10 +1232,11 @@ async def reindex(path: str | None = None, embed: bool = True) -> str:
     Args:
         path: Optional specific directory to re-index (default: entire repo)
         embed: Also refresh embeddings, using the model this index already
-            holds (or SRCLIGHT_EMBED_MODEL). Pass False for a keyword-only
-            refresh when you just need search_symbols current — embedding a
-            large backlog calls the embedding model and can take minutes.
-            Ignored when the index holds no embeddings.
+            holds (or SRCLIGHT_EMBED_MODEL, which applies even to an index
+            that holds none yet). Pass False for a keyword-only refresh when
+            you just need search_symbols current — embedding a large backlog
+            calls the embedding model and can take minutes. Does nothing when
+            no model is configured or recorded.
     """
     global _vector_cache
     # `path` is used as an index ROOT, not a filter: Indexer reads the whole
@@ -1267,12 +1268,17 @@ async def reindex(path: str | None = None, embed: bool = True) -> str:
 
     root = root.resolve()
     db = _get_db()
+    # Release the vector cache BEFORE indexing, not after: the embedding pass
+    # rewrites embeddings.npy through os.replace, which fails on Windows while
+    # this process still holds the old file mmap'd (np.load(mmap_mode="r")).
+    # _build_embeddings swallows that failure, leaving a sidecar whose version
+    # no longer matches the bumped embedding_cache_version — every later
+    # semantic_search then falls back to a full SQLite scan.
+    _vector_cache = None
+
     config = IndexConfig(root=root, disable_embeddings=not embed)
     indexer = Indexer(db, config)
     stats = indexer.index(root)
-
-    # Invalidate vector cache so next query reloads from fresh sidecar
-    _vector_cache = None
 
     result = {
         "files_indexed": stats.files_indexed,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,10 @@ import pytest
 def _no_ambient_embed_model(monkeypatch):
     """Keep the suite off the network.
 
-    SRCLIGHT_EMBED_MODEL makes any index run build embeddings, and the README
-    tells users to export it. Around twenty tests run a real Indexer, so
-    without this the suite would reach for Ollama on a developer machine that
-    followed the docs. Tests that want the variable set it themselves.
+    SRCLIGHT_EMBED_MODEL makes an index with no recorded model build
+    embeddings, and the README tells users to export it. Around twenty tests
+    run a real Indexer against a fresh index, so without this the suite would
+    reach for Ollama on a developer machine that followed the docs. Tests
+    that want the variable set it themselves.
     """
     monkeypatch.delenv("SRCLIGHT_EMBED_MODEL", raising=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+"""Suite-wide fixtures."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_embed_model(monkeypatch):
+    """Keep the suite off the network.
+
+    SRCLIGHT_EMBED_MODEL makes any index run build embeddings, and the README
+    tells users to export it. Around twenty tests run a real Indexer, so
+    without this the suite would reach for Ollama on a developer machine that
+    followed the docs. Tests that want the variable set it themselves.
+    """
+    monkeypatch.delenv("SRCLIGHT_EMBED_MODEL", raising=False)

--- a/tests/test_embed_model_resolution.py
+++ b/tests/test_embed_model_resolution.py
@@ -602,6 +602,33 @@ def test_workspace_index_reuses_each_project_model(workspace, embed_calls, monke
     assert embed_calls == ["qwen3-embedding"]
 
 
+def test_workspace_index_can_forget_every_project_model(workspace, embed_calls, monkeypatch):
+    """The off switch must reach a workspace too, not just a single repo.
+
+    Otherwise stopping a metered provider across eight projects means
+    visiting each one by hand.
+    """
+    monkeypatch.delenv("SRCLIGHT_EMBED_MODEL", raising=False)
+    db = Database(workspace / ".srclight" / "index.db")
+    db.open()
+    db.remember_embedding_model("qwen3-embedding")
+    db.commit()
+    db.close()
+
+    result = CliRunner().invoke(
+        main, ["workspace", "index", "-w", "embed-ws", "--forget-embed-model"]
+    )
+    assert result.exit_code == 0, result.output
+
+    db = Database(workspace / ".srclight" / "index.db")
+    db.open()
+    try:
+        assert db.detect_embedding_model() is None
+    finally:
+        db.close()
+    assert embed_calls == []
+
+
 def test_workspace_index_honours_no_embed(workspace, embed_calls, monkeypatch):
     """Skipping was asked for explicitly: on eight projects it is minutes."""
     monkeypatch.delenv("SRCLIGHT_EMBED_MODEL", raising=False)

--- a/tests/test_embed_model_resolution.py
+++ b/tests/test_embed_model_resolution.py
@@ -1,0 +1,159 @@
+"""Tests for embedding model resolution.
+
+The model can come from three places, in decreasing priority: the --embed
+flag, the SRCLIGHT_EMBED_MODEL environment variable, and the model already
+stored in the index. The last one is what keeps embeddings alive across the
+flag-less reindexes run by the git hooks and the MCP server.
+"""
+
+import pytest
+from click.testing import CliRunner
+
+from srclight.cli import main
+from srclight.db import Database, FileRecord, SymbolRecord
+from srclight.embeddings import vector_to_bytes
+from srclight.indexer import IndexConfig, Indexer, resolve_embed_model
+
+
+@pytest.fixture
+def db(tmp_path):
+    db = Database(tmp_path / "index.db")
+    db.open()
+    db.initialize()
+    yield db
+    db.close()
+
+
+def _seed_embeddings(db: Database, *models: str) -> None:
+    """Insert one embedded symbol per given model (repeats allowed)."""
+    file_id = db.upsert_file(FileRecord(
+        path="src/main.py", content_hash="abc", mtime=1.0,
+        language="python", size=10, line_count=2,
+    ))
+    for i, model in enumerate(models):
+        sym_id = db.insert_symbol(SymbolRecord(
+            file_id=file_id, kind="function", name=f"f{i}",
+            start_line=i + 1, end_line=i + 1,
+            content=f"def f{i}(): pass", line_count=1,
+        ), "src/main.py")
+        db.upsert_embedding(sym_id, model, 3, vector_to_bytes([0.1, 0.2, 0.3]))
+    db.commit()
+
+
+# --- resolve_embed_model ---
+
+
+def test_explicit_model_wins_over_env_and_index(db, monkeypatch):
+    monkeypatch.setenv("SRCLIGHT_EMBED_MODEL", "voyage-code-3")
+    _seed_embeddings(db, "qwen3-embedding")
+
+    config = IndexConfig(embed_model="embed-v4.0")
+
+    assert resolve_embed_model(db, config) == "embed-v4.0"
+
+
+def test_env_var_is_used_when_no_model_is_given(db, monkeypatch):
+    monkeypatch.setenv("SRCLIGHT_EMBED_MODEL", "voyage-code-3")
+
+    assert resolve_embed_model(db, IndexConfig()) == "voyage-code-3"
+
+
+def test_env_var_wins_over_the_model_stored_in_the_index(db, monkeypatch):
+    monkeypatch.setenv("SRCLIGHT_EMBED_MODEL", "voyage-code-3")
+    _seed_embeddings(db, "qwen3-embedding")
+
+    assert resolve_embed_model(db, IndexConfig()) == "voyage-code-3"
+
+
+def test_model_stored_in_the_index_is_reused(db, monkeypatch):
+    monkeypatch.delenv("SRCLIGHT_EMBED_MODEL", raising=False)
+    _seed_embeddings(db, "qwen3-embedding")
+
+    assert resolve_embed_model(db, IndexConfig()) == "qwen3-embedding"
+
+
+def test_the_dominant_model_wins_when_the_index_holds_several(db, monkeypatch):
+    monkeypatch.delenv("SRCLIGHT_EMBED_MODEL", raising=False)
+    _seed_embeddings(db, "voyage-code-3", "qwen3-embedding", "qwen3-embedding")
+
+    assert resolve_embed_model(db, IndexConfig()) == "qwen3-embedding"
+
+
+def test_a_fresh_index_resolves_to_no_model(db, monkeypatch):
+    monkeypatch.delenv("SRCLIGHT_EMBED_MODEL", raising=False)
+
+    assert resolve_embed_model(db, IndexConfig()) is None
+
+
+def test_blank_values_are_ignored(db, monkeypatch):
+    monkeypatch.setenv("SRCLIGHT_EMBED_MODEL", "   ")
+    _seed_embeddings(db, "qwen3-embedding")
+
+    assert resolve_embed_model(db, IndexConfig(embed_model="  ")) == "qwen3-embedding"
+
+
+def test_disable_embeddings_overrides_every_source(db, monkeypatch):
+    monkeypatch.setenv("SRCLIGHT_EMBED_MODEL", "voyage-code-3")
+    _seed_embeddings(db, "qwen3-embedding")
+
+    config = IndexConfig(embed_model="embed-v4.0", disable_embeddings=True)
+
+    assert resolve_embed_model(db, config) is None
+
+
+# --- CLI wiring ---
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A one-file repository, already indexed once."""
+    (tmp_path / "main.py").write_text("def hello():\n    return 1\n")
+    result = CliRunner().invoke(main, ["index", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    return tmp_path
+
+
+@pytest.fixture
+def embed_calls(monkeypatch):
+    """Record the model each index run hands to the embedding builder."""
+    calls: list[str] = []
+
+    def fake_build(self, model_spec):
+        calls.append(model_spec)
+        return 0
+
+    monkeypatch.setattr(Indexer, "_build_embeddings", fake_build)
+    return calls
+
+
+def test_index_reuses_the_model_stored_in_the_index(repo, embed_calls, monkeypatch):
+    monkeypatch.delenv("SRCLIGHT_EMBED_MODEL", raising=False)
+    db = Database(repo / ".srclight" / "index.db")
+    db.open()
+    sym_id = db.conn.execute("SELECT id FROM symbols LIMIT 1").fetchone()["id"]
+    db.upsert_embedding(sym_id, "qwen3-embedding", 3, vector_to_bytes([0.1, 0.2, 0.3]))
+    db.commit()
+    db.close()
+
+    result = CliRunner().invoke(main, ["index", str(repo)])
+
+    assert result.exit_code == 0, result.output
+    assert embed_calls == ["qwen3-embedding"]
+
+
+def test_index_reads_the_model_from_the_environment(repo, embed_calls, monkeypatch):
+    monkeypatch.setenv("SRCLIGHT_EMBED_MODEL", "voyage-code-3")
+
+    result = CliRunner().invoke(main, ["index", str(repo)])
+
+    assert result.exit_code == 0, result.output
+    assert embed_calls == ["voyage-code-3"]
+
+
+def test_no_embed_skips_the_stored_model(repo, embed_calls, monkeypatch):
+    monkeypatch.setenv("SRCLIGHT_EMBED_MODEL", "voyage-code-3")
+
+    result = CliRunner().invoke(main, ["index", str(repo), "--no-embed"])
+
+    assert result.exit_code == 0, result.output
+    assert embed_calls == []

--- a/tests/test_embed_model_resolution.py
+++ b/tests/test_embed_model_resolution.py
@@ -143,6 +143,21 @@ def test_a_failed_run_records_nothing(repo, stub_provider, monkeypatch):
         db.close()
 
 
+def test_forgetting_survives_an_exported_env_var(db, monkeypatch):
+    """The off switch must be an off switch for the user the README created.
+
+    The docs tell people to export SRCLIGHT_EMBED_MODEL, and the hooks
+    inherit it. If the variable outranks a deliberate forget, the one person
+    who most needs to stop calling a metered provider — the one who exported
+    it — cannot, and four user-facing strings promise otherwise.
+    """
+    monkeypatch.setenv("SRCLIGHT_EMBED_MODEL", "voyage-code-3")
+    _seed_embeddings(db, "qwen3-embedding")
+    db.forget_embedding_model()
+
+    assert resolve_embed_model(db, IndexConfig()) is None
+
+
 def test_a_fresh_index_resolves_to_no_model(db, monkeypatch):
     monkeypatch.delenv("SRCLIGHT_EMBED_MODEL", raising=False)
 

--- a/tests/test_embed_model_resolution.py
+++ b/tests/test_embed_model_resolution.py
@@ -79,6 +79,58 @@ def test_the_dominant_model_wins_when_the_index_holds_several(db, monkeypatch):
     assert resolve_embed_model(db, IndexConfig()) == "qwen3-embedding"
 
 
+def test_the_recorded_model_beats_the_row_counts(db, monkeypatch):
+    """A half-finished switch must not silently revert on the next run.
+
+    embed_symbols returns what it managed to embed when a batch fails, so an
+    index can end up mostly old-model, partly new-model. Row counting would
+    hand the majority back and re-embed the new rows into the old model,
+    paying for the calls twice.
+    """
+    monkeypatch.delenv("SRCLIGHT_EMBED_MODEL", raising=False)
+    _seed_embeddings(db, "qwen3-embedding", "qwen3-embedding", "voyage-code-3")
+    db.remember_embedding_model("voyage-code-3")
+
+    assert resolve_embed_model(db, IndexConfig()) == "voyage-code-3"
+
+
+def test_row_counts_still_answer_for_indexes_built_before_the_record(db, monkeypatch):
+    monkeypatch.delenv("SRCLIGHT_EMBED_MODEL", raising=False)
+    _seed_embeddings(db, "qwen3-embedding")
+
+    assert db.detect_embedding_model() == "qwen3-embedding"
+
+
+def test_an_embedding_run_records_the_model_it_used(repo, stub_provider, monkeypatch):
+    monkeypatch.delenv("SRCLIGHT_EMBED_MODEL", raising=False)
+
+    result = CliRunner().invoke(main, ["index", str(repo), "--embed", "stub-model"])
+    assert result.exit_code == 0, result.output
+
+    db = Database(repo / ".srclight" / "index.db")
+    db.open()
+    try:
+        assert db.detect_embedding_model() == "stub-model"
+    finally:
+        db.close()
+
+
+def test_a_failed_run_records_nothing(repo, stub_provider, monkeypatch):
+    """A typo'd model must not become the index's remembered choice."""
+    monkeypatch.delenv("SRCLIGHT_EMBED_MODEL", raising=False)
+    stub_provider["results"] = []  # every batch failed
+
+    result = CliRunner().invoke(main, ["index", str(repo), "--embed", "typo-model"])
+    assert result.exit_code == 0, result.output
+
+    db = Database(repo / ".srclight" / "index.db")
+    db.open()
+    try:
+        assert db.detect_embedding_model() is None
+    finally:
+        db.close()
+
+
 def test_a_fresh_index_resolves_to_no_model(db, monkeypatch):
     monkeypatch.delenv("SRCLIGHT_EMBED_MODEL", raising=False)
 
@@ -111,6 +163,34 @@ def repo(tmp_path):
     result = CliRunner().invoke(main, ["index", str(tmp_path)])
     assert result.exit_code == 0, result.output
     return tmp_path
+
+
+@pytest.fixture
+def stub_provider(monkeypatch):
+    """Embed for real against a fake provider — no network, no Ollama.
+
+    `results` is what embed_symbols hands back; empty means every batch failed.
+    """
+    from srclight import embeddings as embeddings_mod
+
+    state: dict = {"results": None}
+
+    class _Stub:
+        def __init__(self, spec):
+            self.name = spec
+            self.dimensions = 3
+
+    def fake_get_provider(model_spec, **kwargs):
+        return _Stub(model_spec)
+
+    def fake_embed_symbols(provider, symbols, on_progress=None):
+        if state["results"] is not None:
+            return state["results"]
+        return [(s["id"], vector_to_bytes([0.1, 0.2, 0.3])) for s in symbols]
+
+    monkeypatch.setattr(embeddings_mod, "get_provider", fake_get_provider)
+    monkeypatch.setattr(embeddings_mod, "embed_symbols", fake_embed_symbols)
+    return state
 
 
 @pytest.fixture
@@ -201,3 +281,27 @@ def test_reindex_skips_embeddings_when_the_agent_asks(mcp_repo, embed_calls):
     _call(mcp_repo.reindex(embed=False))
 
     assert embed_calls == []
+
+
+def test_reindex_releases_the_vector_cache_before_indexing(mcp_repo, embed_calls, monkeypatch):
+    """The embedding pass rewrites embeddings.npy — which the server may hold mmap'd.
+
+    `os.replace` over a live mapping fails on Windows, _build_embeddings
+    swallows it, and the sidecar then keeps a version the bumped
+    embedding_cache_version no longer matches: every semantic_search falls
+    back to a full SQLite scan for the life of the server. Releasing the
+    cache after indexing, as reindex used to, is too late.
+    """
+    seen = {}
+    real_index = Indexer.index
+
+    def spy(self, root, **kwargs):
+        seen["cache"] = mcp_repo._vector_cache
+        return real_index(self, root, **kwargs)
+
+    monkeypatch.setattr(Indexer, "index", spy)
+    mcp_repo._vector_cache = object()  # stand-in for a mapped sidecar
+
+    _call(mcp_repo.reindex())
+
+    assert seen["cache"] is None, "sidecar still mapped while the embedding pass rewrote it"

--- a/tests/test_embed_model_resolution.py
+++ b/tests/test_embed_model_resolution.py
@@ -1,9 +1,10 @@
 """Tests for embedding model resolution.
 
 The model can come from three places, in decreasing priority: the --embed
-flag, the SRCLIGHT_EMBED_MODEL environment variable, and the model already
-stored in the index. The last one is what keeps embeddings alive across the
-flag-less reindexes run by the git hooks and the MCP server.
+flag, the model recorded in the index, and SRCLIGHT_EMBED_MODEL. The middle
+one is what keeps embeddings alive across the flag-less reindexes run by the
+git hooks and the MCP server; the variable comes last so that exporting it
+never switches an index that already embeds.
 """
 
 import pytest
@@ -13,6 +14,8 @@ from srclight.cli import main
 from srclight.db import Database, FileRecord, SymbolRecord
 from srclight.embeddings import vector_to_bytes
 from srclight.indexer import IndexConfig, Indexer, resolve_embed_model
+
+from .test_workspace import ws_dir  # noqa: F401  (fixture re-export)
 
 
 @pytest.fixture
@@ -119,7 +122,7 @@ def test_an_embedding_run_records_the_model_it_used(repo, stub_provider, monkeyp
     db = Database(repo / ".srclight" / "index.db")
     db.open()
     try:
-        assert db.detect_embedding_model() == "stub-model"
+        assert db.detect_embedding_model() == "stub:stub-model"
     finally:
         db.close()
 
@@ -186,7 +189,11 @@ def stub_provider(monkeypatch):
 
     class _Stub:
         def __init__(self, spec):
-            self.name = spec
+            # Real providers qualify the name they report (OllamaProvider
+            # turns "qwen3-embedding" into "ollama:qwen3-embedding"), and it
+            # is that name which gets recorded and later re-resolved. A stub
+            # echoing the spec back would hide every naming regression.
+            self.name = spec if ":" in spec else f"stub:{spec}"
             self.dimensions = 3
 
     def fake_get_provider(model_spec, **kwargs):
@@ -230,6 +237,71 @@ def test_index_reuses_the_model_stored_in_the_index(repo, embed_calls, monkeypat
     assert embed_calls == ["qwen3-embedding"]
 
 
+def test_switching_the_model_updates_the_record(repo, stub_provider, monkeypatch):
+    """A successful switch must overwrite the record, not leave the old one.
+
+    With the record write ignoring conflicts, `--embed model-b` on a model-a
+    index succeeds, the record stays model-a, and every flag-less hook run
+    after it reverts — re-embedding the new rows back and paying twice.
+    """
+    monkeypatch.delenv("SRCLIGHT_EMBED_MODEL", raising=False)
+    assert CliRunner().invoke(main, ["index", str(repo), "--embed", "model-a"]).exit_code == 0
+    assert CliRunner().invoke(main, ["index", str(repo), "--embed", "model-b"]).exit_code == 0
+
+    db = Database(repo / ".srclight" / "index.db")
+    db.open()
+    try:
+        assert db.detect_embedding_model() == "stub:model-b"
+    finally:
+        db.close()
+
+
+def test_the_pin_survives_the_index_losing_its_embeddings_mid_run(repo, embed_calls, monkeypatch):
+    """The CLI announces a model before the file pass, and must honour it.
+
+    Resolving a second time inside the indexer can disagree: a checkout that
+    drops every embedded file cascade-deletes its embeddings during the pass,
+    so the later resolve finds nothing and silently skips embedding — after
+    the CLI has already printed the model it was going to use.
+    """
+    monkeypatch.delenv("SRCLIGHT_EMBED_MODEL", raising=False)
+    embedded_file = repo / "main.py"
+
+    db = Database(repo / ".srclight" / "index.db")
+    db.open()
+    sym_id = db.conn.execute("SELECT id FROM symbols LIMIT 1").fetchone()["id"]
+    db.upsert_embedding(sym_id, "qwen3-embedding", 3, vector_to_bytes([0.1, 0.2, 0.3]))
+    db.commit()
+    db.close()
+
+    # The one embedded file disappears: its symbols, and their embeddings,
+    # go with it during the run that follows.
+    embedded_file.unlink()
+    (repo / "replacement.py").write_text("def replacement():\n    return 2\n")
+
+    result = CliRunner().invoke(main, ["index", str(repo)])
+
+    assert result.exit_code == 0, result.output
+    assert "Embedding model: qwen3-embedding" in result.output
+    assert embed_calls == ["qwen3-embedding"], "announced a model, then embedded with none"
+
+
+def test_index_reports_the_model_it_actually_uses(repo, embed_calls, monkeypatch):
+    """The message and the call must not be able to drift apart."""
+    monkeypatch.delenv("SRCLIGHT_EMBED_MODEL", raising=False)
+    db = Database(repo / ".srclight" / "index.db")
+    db.open()
+    db.remember_embedding_model("qwen3-embedding")
+    db.commit()
+    db.close()
+
+    result = CliRunner().invoke(main, ["index", str(repo)])
+
+    assert result.exit_code == 0, result.output
+    assert embed_calls == ["qwen3-embedding"]
+    assert "Embedding model: qwen3-embedding (from the existing index)" in result.output
+
+
 def test_index_reads_the_model_from_the_environment(repo, embed_calls, monkeypatch):
     monkeypatch.setenv("SRCLIGHT_EMBED_MODEL", "voyage-code-3")
 
@@ -241,6 +313,11 @@ def test_index_reads_the_model_from_the_environment(repo, embed_calls, monkeypat
 
 def test_no_embed_skips_the_stored_model(repo, embed_calls, monkeypatch):
     monkeypatch.setenv("SRCLIGHT_EMBED_MODEL", "voyage-code-3")
+    db = Database(repo / ".srclight" / "index.db")
+    db.open()
+    db.remember_embedding_model("qwen3-embedding")
+    db.commit()
+    db.close()
 
     result = CliRunner().invoke(main, ["index", str(repo), "--no-embed"])
 
@@ -396,6 +473,9 @@ def mcp_repo(repo, monkeypatch):
     # _get_db() walks up from the CWD — never let a test reach the real index.
     monkeypatch.chdir(repo)
     monkeypatch.delenv("SRCLIGHT_EMBED_MODEL", raising=False)
+    # test_web.py leaves this set for the rest of the session; reindex must
+    # be exercised in single-repo mode whatever ran before us.
+    monkeypatch.setattr(server_mod, "_workspace_name", None)
 
     db_path = repo / ".srclight" / "index.db"
     db = Database(db_path)
@@ -487,3 +567,53 @@ def test_reindex_releases_the_vector_cache_before_indexing(mcp_repo, embed_calls
     _call(mcp_repo.reindex())
 
     assert seen["cache"] is None, "sidecar still mapped while the embedding pass rewrote it"
+
+
+# --- workspace index ---
+
+
+@pytest.fixture
+def workspace(tmp_path, ws_dir):  # noqa: F811
+    """A workspace holding one already-indexed project."""
+    from srclight.workspace import WorkspaceConfig
+
+    project = tmp_path / "alpha"
+    project.mkdir()
+    (project / "main.py").write_text("def hello():\n    return 1\n")
+    assert CliRunner().invoke(main, ["index", str(project)]).exit_code == 0
+
+    config = WorkspaceConfig(name="embed-ws")
+    config.add_project("alpha", str(project))
+    config.save()
+    return project
+
+
+def test_workspace_index_reuses_each_project_model(workspace, embed_calls, monkeypatch):
+    monkeypatch.delenv("SRCLIGHT_EMBED_MODEL", raising=False)
+    db = Database(workspace / ".srclight" / "index.db")
+    db.open()
+    db.remember_embedding_model("qwen3-embedding")
+    db.commit()
+    db.close()
+
+    result = CliRunner().invoke(main, ["workspace", "index", "-w", "embed-ws"])
+
+    assert result.exit_code == 0, result.output
+    assert embed_calls == ["qwen3-embedding"]
+
+
+def test_workspace_index_honours_no_embed(workspace, embed_calls, monkeypatch):
+    """Skipping was asked for explicitly: on eight projects it is minutes."""
+    monkeypatch.delenv("SRCLIGHT_EMBED_MODEL", raising=False)
+    db = Database(workspace / ".srclight" / "index.db")
+    db.open()
+    db.remember_embedding_model("qwen3-embedding")
+    db.commit()
+    db.close()
+
+    result = CliRunner().invoke(
+        main, ["workspace", "index", "-w", "embed-ws", "--embed", "voyage-code-3", "--no-embed"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert embed_calls == []

--- a/tests/test_embed_model_resolution.py
+++ b/tests/test_embed_model_resolution.py
@@ -401,6 +401,40 @@ def test_a_skipped_embedding_pass_marks_the_sidecar_stale(repo, stub_provider):
 # --- an embedding pass must never cost the index ---
 
 
+def test_a_failed_embedding_pass_marks_the_sidecar_stale(repo, stub_provider, monkeypatch):
+    """Nothing embedded is nothing embedded, whatever the reason.
+
+    Invalidating only when no model resolved left the ordinary cases out:
+    the provider is down, or the reindex only removed files. The run then
+    reports success while the sidecar describes a database that has moved —
+    and symbols.id is a rowid, reused after deletion, so semantic_search
+    serves one symbol's score under another symbol's identity.
+    """
+    monkeypatch.delenv("SRCLIGHT_EMBED_MODEL", raising=False)
+    assert CliRunner().invoke(main, ["index", str(repo), "--embed", "stub-model"]).exit_code == 0
+
+    db_path = repo / ".srclight" / "index.db"
+
+    def version():
+        db = Database(db_path)
+        db.open()
+        try:
+            return db.conn.execute(
+                "SELECT value FROM schema_info WHERE key='embedding_cache_version'"
+            ).fetchone()["value"]
+        finally:
+            db.close()
+
+    before = version()
+    stub_provider["results"] = []  # provider down: every batch failed
+    (repo / "main.py").write_text("def replaced():\n    return 2\n")
+
+    result = CliRunner().invoke(main, ["index", str(repo)])
+
+    assert result.exit_code == 0, result.output
+    assert version() != before, "sidecar still trusted after a pass that embedded nothing"
+
+
 def test_an_unreachable_provider_does_not_lose_the_index(tmp_path, monkeypatch):
     """The whole run used to roll back when the provider was down.
 
@@ -555,6 +589,88 @@ def test_the_server_heals_a_sidecar_another_process_could_not_replace(repo, stub
 
         assert healed is not None
         assert healed.is_valid(server_mod._get_db().conn), "sidecar left stale for the session"
+    finally:
+        server_mod._close_databases()
+        server_mod.configure(db_path=None, repo_root=None)
+
+
+def test_a_sidecar_this_process_cannot_replace_is_attempted_once(repo, stub_provider, monkeypatch):
+    """Another long-lived reader can hold the file mapped; do not thrash.
+
+    On failure the old code dropped the cache and returned None, so the next
+    call cold-loaded the intact-but-stale sidecar and the one after that
+    rebuilt again — every other search paying a full matrix build (~440 MB
+    written for a 27K x 4096 index) forever.
+    """
+    from srclight import server as server_mod
+    from srclight.vector_cache import VectorCache
+
+    assert CliRunner().invoke(main, ["index", str(repo), "--embed", "stub-model"]).exit_code == 0
+
+    db_path = repo / ".srclight" / "index.db"
+    monkeypatch.setattr(server_mod, "_workspace_name", None)
+    server_mod.configure(db_path=db_path, repo_root=repo)
+    try:
+        assert server_mod._get_vector_cache().is_loaded()
+
+        attempts = []
+        real_build = VectorCache.build_from_db
+
+        def failing_build(self, conn):
+            attempts.append(1)
+            raise PermissionError("[WinError 5] the file is mapped by another process")
+
+        monkeypatch.setattr(VectorCache, "build_from_db", failing_build)
+
+        other = Database(db_path)
+        other.open()
+        sym_id = other.conn.execute("SELECT id FROM symbols LIMIT 1").fetchone()["id"]
+        other.upsert_embedding(sym_id, "stub:stub-model", 3, vector_to_bytes([0.9, 0.9, 0.9]))
+        other.commit()
+        other.close()
+
+        for _ in range(4):
+            server_mod._get_vector_cache()
+
+        assert len(attempts) == 1, f"rebuilt {len(attempts)} times for one stale version"
+        assert real_build is not None  # keep the reference honest
+    finally:
+        server_mod._close_databases()
+        server_mod.configure(db_path=None, repo_root=None)
+
+
+def test_a_rebuild_publishes_a_new_cache_rather_than_reloading_in_place(repo, stub_provider,
+                                                                        monkeypatch):
+    """Rebinding, so nothing observes a half-swapped cache.
+
+    The old object is emptied first — its mmap has to go before os.replace
+    can land on Windows — but it is never refilled in place, so a thread
+    holding it either searches a complete matrix or none at all, and never a
+    matrix whose rows no longer match its symbol_ids.
+    """
+    from srclight import server as server_mod
+
+    assert CliRunner().invoke(main, ["index", str(repo), "--embed", "stub-model"]).exit_code == 0
+
+    db_path = repo / ".srclight" / "index.db"
+    monkeypatch.setattr(server_mod, "_workspace_name", None)
+    server_mod.configure(db_path=db_path, repo_root=repo)
+    try:
+        in_flight = server_mod._get_vector_cache()
+        assert in_flight.is_loaded()
+
+        other = Database(db_path)
+        other.open()
+        sym_id = other.conn.execute("SELECT id FROM symbols LIMIT 1").fetchone()["id"]
+        other.upsert_embedding(sym_id, "stub:stub-model", 3, vector_to_bytes([0.9, 0.9, 0.9]))
+        other.commit()
+        other.close()
+
+        rebuilt = server_mod._get_vector_cache()
+
+        assert rebuilt is not in_flight, "rebuilt in place instead of publishing a new cache"
+        assert rebuilt.is_valid(server_mod._get_db().conn)
+        assert not in_flight.is_loaded(), "the old mmap must be dropped, not refilled"
     finally:
         server_mod._close_databases()
         server_mod.configure(db_path=None, repo_root=None)

--- a/tests/test_embed_model_resolution.py
+++ b/tests/test_embed_model_resolution.py
@@ -46,6 +46,7 @@ def _seed_embeddings(db: Database, *models: str) -> None:
 def test_explicit_model_wins_over_env_and_index(db, monkeypatch):
     monkeypatch.setenv("SRCLIGHT_EMBED_MODEL", "voyage-code-3")
     _seed_embeddings(db, "qwen3-embedding")
+    db.remember_embedding_model("qwen3-embedding")
 
     config = IndexConfig(embed_model="embed-v4.0")
 
@@ -58,11 +59,19 @@ def test_env_var_is_used_when_no_model_is_given(db, monkeypatch):
     assert resolve_embed_model(db, IndexConfig()) == "voyage-code-3"
 
 
-def test_env_var_wins_over_the_model_stored_in_the_index(db, monkeypatch):
+def test_the_stored_model_wins_over_the_env_var(db, monkeypatch):
+    """The variable is a default for indexes that have none, not an override.
+
+    Overriding would mean exporting it once — as the README suggests — then
+    having the next commit in an unrelated repo silently re-embed every
+    symbol it holds, from a detached background hook. Switching an existing
+    index stays an explicit --embed.
+    """
     monkeypatch.setenv("SRCLIGHT_EMBED_MODEL", "voyage-code-3")
     _seed_embeddings(db, "qwen3-embedding")
+    db.remember_embedding_model("qwen3-embedding")
 
-    assert resolve_embed_model(db, IndexConfig()) == "voyage-code-3"
+    assert resolve_embed_model(db, IndexConfig()) == "qwen3-embedding"
 
 
 def test_model_stored_in_the_index_is_reused(db, monkeypatch):
@@ -239,6 +248,137 @@ def test_no_embed_skips_the_stored_model(repo, embed_calls, monkeypatch):
     assert embed_calls == []
 
 
+def test_forgetting_the_model_stops_later_runs_from_embedding(repo, stub_provider, monkeypatch):
+    """Sticky needs an exit, and the hooks' command line is fixed.
+
+    The hooks run a bare `srclight index .`, so --no-embed cannot reach them.
+    Without a way to forget, someone who tried `--embed voyage-code-3` once
+    keeps calling a metered API on every commit and every branch switch, with
+    no supported way out but hand-editing SQLite.
+    """
+    monkeypatch.delenv("SRCLIGHT_EMBED_MODEL", raising=False)
+    assert CliRunner().invoke(main, ["index", str(repo), "--embed", "stub-model"]).exit_code == 0
+
+    result = CliRunner().invoke(main, ["index", str(repo), "--forget-embed-model"])
+    assert result.exit_code == 0, result.output
+
+    db = Database(repo / ".srclight" / "index.db")
+    db.open()
+    try:
+        # The rows are still there; they must not resurrect the choice.
+        assert db.embedding_stats()["embedded_symbols"] > 0
+        assert db.detect_embedding_model() is None
+    finally:
+        db.close()
+
+
+def test_a_skipped_embedding_pass_marks_the_sidecar_stale(repo, stub_provider):
+    """--no-embed still deletes and re-creates symbols; ids get reused.
+
+    symbol_embeddings cascades on symbol deletion and the cache version is
+    bumped only by upsert_embedding, so a --no-embed run that changed symbols
+    left a sidecar that still looked valid while describing the previous
+    index — and semantic_search served rows for reused ids, i.e. one symbol's
+    score attached to another symbol's identity.
+    """
+    assert CliRunner().invoke(main, ["index", str(repo), "--embed", "stub-model"]).exit_code == 0
+
+    db_path = repo / ".srclight" / "index.db"
+    db = Database(db_path)
+    db.open()
+    before = db.conn.execute(
+        "SELECT value FROM schema_info WHERE key='embedding_cache_version'"
+    ).fetchone()["value"]
+    db.close()
+
+    (repo / "added.py").write_text("def added():\n    return 3\n")
+    result = CliRunner().invoke(main, ["index", str(repo), "--no-embed"])
+    assert result.exit_code == 0, result.output
+
+    db = Database(db_path)
+    db.open()
+    try:
+        after = db.conn.execute(
+            "SELECT value FROM schema_info WHERE key='embedding_cache_version'"
+        ).fetchone()["value"]
+        assert after != before, "sidecar still looks valid for a changed index"
+    finally:
+        db.close()
+
+
+# --- an embedding pass must never cost the index ---
+
+
+def test_an_unreachable_provider_does_not_lose_the_index(tmp_path, monkeypatch):
+    """The whole run used to roll back when the provider was down.
+
+    embed_symbols swallows per-batch failures and returns [], then
+    provider.dimensions re-probes the provider and raised out of index(),
+    past the single commit that makes the file pass durable. Every
+    post-commit hook on a machine with Ollama stopped indexed nothing.
+    """
+    from srclight import embeddings as embeddings_mod
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "main.py").write_text("def hello():\n    return 1\n")
+
+    class _DeadProvider:
+        name = "ollama:qwen3-embedding"
+
+        @property
+        def dimensions(self):
+            raise ConnectionError("Cannot reach Ollama at http://localhost:11434")
+
+    def dead_embed_symbols(provider, symbols, on_progress=None):
+        return []  # every batch failed, swallowed inside embed_symbols
+
+    monkeypatch.setattr(embeddings_mod, "get_provider", lambda spec, **kw: _DeadProvider())
+    monkeypatch.setattr(embeddings_mod, "embed_symbols", dead_embed_symbols)
+    monkeypatch.setenv("SRCLIGHT_EMBED_MODEL", "qwen3-embedding")
+
+    result = CliRunner().invoke(main, ["index", str(repo)])
+    assert result.exit_code == 0, result.output
+
+    db = Database(repo / ".srclight" / "index.db")
+    db.open()
+    try:
+        assert db.stats()["files"] == 1, "the file pass was rolled back by the embedding failure"
+        assert db.get_index_state(str(repo.resolve())) is not None
+    finally:
+        db.close()
+
+
+def test_the_file_pass_is_durable_before_embedding_starts(repo, stub_provider, monkeypatch):
+    """Embedding can take minutes; it must not hold the write lock.
+
+    index() committed once at the very end, so the implicit transaction
+    opened by the first file upsert stayed open across every HTTP call. A
+    second writer — the git hook firing while an MCP reindex embeds — hit
+    'database is locked' and lost its own run.
+    """
+    from srclight import embeddings as embeddings_mod
+
+    seen = {}
+    (repo / "later.py").write_text("def later():\n    return 2\n")
+
+    def observing_embed_symbols(provider, symbols, on_progress=None):
+        other = Database(repo / ".srclight" / "index.db")
+        other.open()
+        try:
+            seen["files"] = other.stats()["files"]
+        finally:
+            other.close()
+        return [(s["id"], vector_to_bytes([0.1, 0.2, 0.3])) for s in symbols]
+
+    monkeypatch.setattr(embeddings_mod, "embed_symbols", observing_embed_symbols)
+
+    result = CliRunner().invoke(main, ["index", str(repo), "--embed", "stub-model"])
+    assert result.exit_code == 0, result.output
+
+    assert seen["files"] == 2, "the file pass was still uncommitted while embedding ran"
+
+
 # --- MCP reindex ---
 
 
@@ -281,6 +421,48 @@ def test_reindex_skips_embeddings_when_the_agent_asks(mcp_repo, embed_calls):
     _call(mcp_repo.reindex(embed=False))
 
     assert embed_calls == []
+
+
+def test_the_server_heals_a_sidecar_another_process_could_not_replace(repo, stub_provider):
+    """The git hooks embed from a separate process, and cannot fix the sidecar.
+
+    A running server holds embeddings.npy mmap'd for its whole life, and
+    Windows refuses os.replace on a mapped file — so the hook's rebuild
+    fails, its warning goes to reindex.log, and the sidecar keeps a version
+    the bumped embedding_cache_version no longer matches. Nothing else ever
+    rebuilds it, so semantic_search fell back to a full SQLite scan forever.
+    The server holds the mapping, so the server is who can refresh it.
+    """
+    from srclight import server as server_mod
+
+    result = CliRunner().invoke(main, ["index", str(repo), "--embed", "stub-model"])
+    assert result.exit_code == 0, result.output
+
+    db_path = repo / ".srclight" / "index.db"
+    server_mod.configure(db_path=db_path, repo_root=repo)
+    try:
+        cache = server_mod._get_vector_cache()
+        assert cache is not None and cache.is_loaded(), "no sidecar to start from"
+
+        # Another process embeds: rows land in SQLite and the cache version is
+        # bumped, but the sidecar on disk stays behind.
+        other = Database(db_path)
+        other.open()
+        try:
+            sym_id = other.conn.execute("SELECT id FROM symbols LIMIT 1").fetchone()["id"]
+            other.upsert_embedding(sym_id, "stub-model", 3, vector_to_bytes([0.9, 0.9, 0.9]))
+            other.commit()
+            assert not cache.is_valid(other.conn), "test did not manage to stale the cache"
+        finally:
+            other.close()
+
+        healed = server_mod._get_vector_cache()
+
+        assert healed is not None
+        assert healed.is_valid(server_mod._get_db().conn), "sidecar left stale for the session"
+    finally:
+        server_mod._close_databases()
+        server_mod.configure(db_path=None, repo_root=None)
 
 
 def test_reindex_releases_the_vector_cache_before_indexing(mcp_repo, embed_calls, monkeypatch):

--- a/tests/test_embed_model_resolution.py
+++ b/tests/test_embed_model_resolution.py
@@ -633,7 +633,108 @@ def test_a_sidecar_this_process_cannot_replace_is_attempted_once(repo, stub_prov
             server_mod._get_vector_cache()
 
         assert len(attempts) == 1, f"rebuilt {len(attempts)} times for one stale version"
+
+        # But a NEW version must be tried: the memo is one attempt per state
+        # of the database, not one per server lifetime.
+        other = Database(db_path)
+        other.open()
+        sym_id = other.conn.execute("SELECT id FROM symbols LIMIT 1").fetchone()["id"]
+        other.upsert_embedding(sym_id, "stub:stub-model", 3, vector_to_bytes([0.5, 0.5, 0.5]))
+        other.commit()
+        other.close()
+
+        for _ in range(2):
+            server_mod._get_vector_cache()
+
+        assert len(attempts) == 2, "a newly stale version was never retried"
         assert real_build is not None  # keep the reference honest
+    finally:
+        server_mod._close_databases()
+        server_mod.configure(db_path=None, repo_root=None)
+
+
+def test_the_fast_path_comes_back_once_the_obstruction_lifts(repo, stub_provider, monkeypatch):
+    """A failed rebuild must not pin the server to the SQLite scan for good.
+
+    The rebuild empties our cache before writing, so on failure the global
+    points at an unloaded object. Treating "not loaded" as terminal meant the
+    server never looked at the disk again — every semantic_search paying the
+    full scan for the life of the process, even after the other reader let go
+    and a perfectly good sidecar was written.
+    """
+    from srclight import server as server_mod
+    from srclight.vector_cache import VectorCache
+
+    assert CliRunner().invoke(main, ["index", str(repo), "--embed", "stub-model"]).exit_code == 0
+
+    db_path = repo / ".srclight" / "index.db"
+    monkeypatch.setattr(server_mod, "_workspace_name", None)
+    server_mod.configure(db_path=db_path, repo_root=repo)
+    try:
+        assert server_mod._get_vector_cache().is_loaded()
+
+        real_build = VectorCache.build_from_db
+        blocked = {"on": True}
+
+        def maybe_failing_build(self, conn):
+            if blocked["on"]:
+                raise PermissionError("[WinError 5] mapped by another process")
+            return real_build(self, conn)
+
+        monkeypatch.setattr(VectorCache, "build_from_db", maybe_failing_build)
+
+        # Another process embeds; our rebuild cannot land.
+        (repo / "later.py").write_text("def later():\n    return 2\n")
+        assert CliRunner().invoke(main, ["index", str(repo)]).exit_code == 0
+        server_mod._get_vector_cache()
+
+        # The obstruction lifts and a good sidecar is written from outside.
+        blocked["on"] = False
+        (repo / "third.py").write_text("def third():\n    return 3\n")
+        assert CliRunner().invoke(main, ["index", str(repo)]).exit_code == 0
+
+        cache = server_mod._get_vector_cache()
+
+        assert cache is not None and cache.is_loaded(), "never looked at the disk again"
+        assert cache.is_valid(server_mod._get_db().conn), "stuck on the SQLite scan"
+    finally:
+        server_mod._close_databases()
+        server_mod.configure(db_path=None, repo_root=None)
+
+
+def test_an_index_that_loses_every_embedding_recovers_when_they_return(repo, stub_provider,
+                                                                       monkeypatch):
+    """Rebuilding over an empty table publishes nothing loadable.
+
+    build_from_db early-returns when there are no rows, so the "rebuilt"
+    cache has never been loaded. Publishing it as a success left the server
+    holding a dead object, and a later commit that re-embedded was never
+    picked up. Reached by the ordinary hook workflow: delete the last
+    embedded file, commit, and the flag-less run invalidates.
+    """
+    from srclight import server as server_mod
+
+    assert CliRunner().invoke(main, ["index", str(repo), "--embed", "stub-model"]).exit_code == 0
+
+    db_path = repo / ".srclight" / "index.db"
+    monkeypatch.setattr(server_mod, "_workspace_name", None)
+    server_mod.configure(db_path=db_path, repo_root=repo)
+    try:
+        assert server_mod._get_vector_cache().is_loaded()
+
+        # The last embedded file goes away: symbol_embeddings cascades empty.
+        (repo / "main.py").unlink()
+        assert CliRunner().invoke(main, ["index", str(repo)]).exit_code == 0
+        server_mod._get_vector_cache()
+
+        # Code comes back and is embedded again.
+        (repo / "back.py").write_text("def back():\n    return 4\n")
+        assert CliRunner().invoke(main, ["index", str(repo)]).exit_code == 0
+
+        cache = server_mod._get_vector_cache()
+
+        assert cache is not None and cache.is_loaded(), "left holding a dead cache"
+        assert cache.is_valid(server_mod._get_db().conn)
     finally:
         server_mod._close_databases()
         server_mod.configure(db_path=None, repo_root=None)

--- a/tests/test_embed_model_resolution.py
+++ b/tests/test_embed_model_resolution.py
@@ -157,3 +157,47 @@ def test_no_embed_skips_the_stored_model(repo, embed_calls, monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert embed_calls == []
+
+
+# --- MCP reindex ---
+
+
+def _call(coro_or_val):
+    """Run an async MCP tool the way the rest of the suite does."""
+    import asyncio
+    return asyncio.run(coro_or_val) if asyncio.iscoroutine(coro_or_val) else coro_or_val
+
+
+@pytest.fixture
+def mcp_repo(repo, monkeypatch):
+    """An indexed repo, already embedded once, served over MCP."""
+    from srclight import server as server_mod
+
+    # _get_db() walks up from the CWD — never let a test reach the real index.
+    monkeypatch.chdir(repo)
+    monkeypatch.delenv("SRCLIGHT_EMBED_MODEL", raising=False)
+
+    db_path = repo / ".srclight" / "index.db"
+    db = Database(db_path)
+    db.open()
+    sym_id = db.conn.execute("SELECT id FROM symbols LIMIT 1").fetchone()["id"]
+    db.upsert_embedding(sym_id, "qwen3-embedding", 3, vector_to_bytes([0.1, 0.2, 0.3]))
+    db.commit()
+    db.close()
+
+    server_mod.configure(db_path=db_path, repo_root=repo)
+    yield server_mod
+    server_mod._close_databases()
+    server_mod.configure(db_path=None, repo_root=None)
+
+
+def test_reindex_embeds_with_the_known_model_by_default(mcp_repo, embed_calls):
+    _call(mcp_repo.reindex())
+
+    assert embed_calls == ["qwen3-embedding"]
+
+
+def test_reindex_skips_embeddings_when_the_agent_asks(mcp_repo, embed_calls):
+    _call(mcp_repo.reindex(embed=False))
+
+    assert embed_calls == []

--- a/tests/test_embed_model_resolution.py
+++ b/tests/test_embed_model_resolution.py
@@ -653,6 +653,54 @@ def test_a_sidecar_this_process_cannot_replace_is_attempted_once(repo, stub_prov
         server_mod.configure(db_path=None, repo_root=None)
 
 
+def test_a_reader_during_a_rebuild_does_not_remap_the_file(repo, stub_provider, monkeypatch):
+    """The rebuild drops our mmap on purpose; a reader must not put it back.
+
+    Search tools are sync MCP tools, so FastMCP runs them on worker threads
+    and a second search during a rebuild is ordinary. Reaching the cold path
+    there re-maps the very file the rebuilder is about to os.replace, which
+    on Windows makes the rebuild fail — defeating the whole reason the
+    rebuild happens in this process.
+    """
+    from srclight import server as server_mod
+    from srclight.vector_cache import VectorCache
+
+    assert CliRunner().invoke(main, ["index", str(repo), "--embed", "stub-model"]).exit_code == 0
+
+    db_path = repo / ".srclight" / "index.db"
+    monkeypatch.setattr(server_mod, "_workspace_name", None)
+    server_mod.configure(db_path=db_path, repo_root=repo)
+    try:
+        assert server_mod._get_vector_cache().is_loaded()
+
+        observed = {}
+        real_build = VectorCache.build_from_db
+
+        def build_with_a_reader_in_the_middle(self, conn):
+            # Stands in for the other worker thread, at the exact moment our
+            # mapping is gone and the replace has not happened yet.
+            concurrent = server_mod._get_vector_cache()
+            observed["remapped"] = concurrent is not None and concurrent.is_loaded()
+            return real_build(self, conn)
+
+        monkeypatch.setattr(VectorCache, "build_from_db", build_with_a_reader_in_the_middle)
+
+        other = Database(db_path)
+        other.open()
+        sym_id = other.conn.execute("SELECT id FROM symbols LIMIT 1").fetchone()["id"]
+        other.upsert_embedding(sym_id, "stub:stub-model", 3, vector_to_bytes([0.9, 0.9, 0.9]))
+        other.commit()
+        other.close()
+
+        rebuilt = server_mod._get_vector_cache()
+
+        assert observed.get("remapped") is False, "a reader re-mapped the file mid-rebuild"
+        assert rebuilt is not None and rebuilt.is_loaded(), "the rebuild did not land"
+    finally:
+        server_mod._close_databases()
+        server_mod.configure(db_path=None, repo_root=None)
+
+
 def test_the_fast_path_comes_back_once_the_obstruction_lifts(repo, stub_provider, monkeypatch):
     """A failed rebuild must not pin the server to the SQLite scan for good.
 


### PR DESCRIPTION
## Problem

`--embed <model>` had to be retyped on every run. An index built with
`srclight index --embed qwen3-embedding` produced **no embeddings at all** on
the next bare `srclight index`.

That matters more than the typing, because the runs that matter are flag-less:
the `post-commit` / `post-checkout` hooks installed by `hook install` run
`srclight index .`, and so does the MCP `reindex` tool. Every symbol added
after the first embedding pass stayed unembedded until someone remembered the
flag by hand, and `hybrid_search` quietly degraded to its keyword half on
exactly the code being worked on.

## What this does

The index records the model it embeds with, and every later run reuses it.

```bash
srclight index --embed qwen3-embedding   # first run: records the model
srclight index                           # later runs: reuse it, no flag
```

Resolution order: `--embed` > **the model recorded in the index** >
`SRCLIGHT_EMBED_MODEL`.

The environment variable comes last on purpose. As an override, exporting it
once — the natural way to set a default — would make the next commit in an
unrelated repo silently re-embed every symbol it holds, from a detached
background hook, against a metered API in the paid case. It is a default for
indexes that have none, not a switch.

Three ways out, because sticky state needs an exit and the hooks' command line
is fixed at `srclight index .`:

| | |
|---|---|
| `--no-embed` | skip embedding for one run |
| `--forget-embed-model` | stop embedding this index until `--embed` returns |
| `reindex(embed=False)` | the per-call equivalent over MCP |

`embedding_status()` gained `configured_model`: the model the next flag-less run
resolves to, null meaning it will not embed.

## Scope

Making flag-less runs embed put three pre-existing defects onto the default
path. They are **amplified by this branch, not opened by it** — each moves from
a path a user opted into to the one every git hook takes. Fixing them here is
what makes the feature safe to turn on:

- **An unreachable provider took the whole index down.** `embed_symbols`
  swallows per-batch failures and returns `[]`, then `provider.dimensions`
  re-probed the network and raised out of `index()`, past the single commit that
  makes the file pass durable. Reproduced: exit 1, **zero files in the
  database**, no `index_state`, on a run that printed its progress. On `develop`
  this needed an explicit `--embed` against a dead Ollama; here it would be
  every commit. `index()` now commits the file pass before embedding, and
  nothing escapes `_build_embeddings`.
- **The embedding pass held the SQLite write lock for its whole duration.** No
  `busy_timeout` is set, so a hook firing during a reindex got
  `database is locked` and lost its own run. Same commit fixes it.
- **The sidecar could not be rebuilt by the process that embeds.** A running
  server holds `embeddings.npy` mmap'd for its whole life and Windows refuses
  `os.replace` on a mapped file, so a hook's rebuild failed silently and every
  later `semantic_search` fell back to a full SQLite scan for the life of the
  server. The server holds the mapping, so the server now refreshes it.

Deliberately **not** touched, all pre-existing on `develop`: `reindex` is
`async def` calling a synchronous `index()` on the event loop; `_atomic_write`
cannot replace a file mapped by another process on Windows (it has its own
failing test on `develop`); sidecars mixing two embedding spaces of equal
dimensionality.

## Hunks a reviewer will rightly question

- **`Indexer.index()` commits before the embedding pass** — changes transaction
  boundaries for *every* run, including ones that existed before. Justified by
  the data-loss and lock findings above.
- **`_get_vector_cache()` / `_rebuild_vector_cache()`** — new behaviour in
  server code the feature does not create. Justified only because the feature
  makes the sidecar get rewritten from another process. This is the most
  contested hunk in the PR; happy to split it out if you'd rather.
- **`--forget-embed-model`** — new CLI surface, but it is the exit from the
  sticky state this feature introduces, and `--no-embed` cannot reach the hooks.

## Testing

37 new tests in `tests/test_embed_model_resolution.py`. Full suite: **437
passed**, plus the 10 failures that are already red on `develop` on Windows
(`test_hooks`, `test_index_dart`, `test_vector_cache::test_rebuild_replaces…`,
7× `test_workspace::test_read_only_uri…`). Ruff: no new findings on the
modified files.

New `tests/conftest.py` clears `SRCLIGHT_EMBED_MODEL` suite-wide. It is
load-bearing, not tidiness: **45 tests** would otherwise reach for Ollama on a
machine that followed the README, ~37 of them pre-existing.

Verified end to end against a real Ollama: model reuse across runs, recovery
when the provider is unreachable, `--forget-embed-model`, and the sidecar
rebuild while a server holds it mapped.