### PR TITLE
feat: run any MCP tool from the shell, and say when find_pattern truncated

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,24 @@ srclight serve
 
 > **Note:** `srclight index` automatically adds `.srclight/` to your `.gitignore`. Index databases and embedding files can be large and should never be committed.
 
+### Running tools from the shell
+
+Every MCP tool is reachable from the CLI, which is how an agent with a
+sandbox can query the index without the answer ever entering its context:
+
+```bash
+srclight tool --list                    # every tool and what it does
+srclight tool find_pattern --help       # arguments, from the tool's own schema
+srclight tool find_pattern --pattern 'this->timer' --kind function --limit 80
+```
+
+Output is the tool's JSON on stdout and nothing else, so it pipes. Exit codes
+are 0 on success, 1 when the tool reports an error, 2 on a usage error.
+
+The command reads the server's own tool registry, so it always matches the
+tools your MCP client sees — and a tool renamed on the MCP side is renamed
+here too.
+
 ## Semantic Search (Embeddings)
 
 Srclight supports embedding-based semantic search for natural language queries like "find code that handles authentication" or "where is the database connection pool".

--- a/docs/superpowers/specs/2026-09-11-cli-tool-dispatcher-design.md
+++ b/docs/superpowers/specs/2026-09-11-cli-tool-dispatcher-design.md
@@ -1,0 +1,233 @@
+# `srclight tool` — a CLI dispatcher over the MCP tools
+
+*2026-09-11 — design*
+
+## Problem
+
+An agent working a large C codebase (hundreds of thousands of symbols) hit two
+distinct failures using `find_pattern` through MCP. They are worth separating,
+because they call for different fixes.
+
+**Overflow.** `find_pattern` returns the full JSON: for every match, the
+containing symbol plus its `matched_lines`, each carrying the complete source
+line. Measured in one session:
+
+| Query shape | Volume |
+|---|---|
+| One frequently called helper (kind=function, limit=300) | 161 870 characters — refused by the harness, spilled to a file |
+| A common struct field access (language=c, kind=function, limit=80) | 74 654 characters — same |
+| An alternation over two frequent identifiers (limit=40) | ~10k tokens swallowed at once |
+| An alternation over two receiver spellings assigning a field (limit=60) | ~10.1k tokens |
+
+When it overflows, the harness writes the result to a file and requires reading
+it back in full — so the context is paid twice. The agent worked around it by
+querying `.srclight/index.db` in SQL from a sandbox, which is the signal that
+the tool surface is missing something.
+
+**Silent truncation.** `find_pattern_in_symbols` stops at `limit` with no
+signal (`src/srclight/db.py:1866`, `if len(results) >= limit: break`). On the
+last query above the agent got `match_count: 60` with `limit: 60`, concluded
+the sweep had converged, and was wrong: at least one symbol matching the
+pattern was absent from the list, and only a separate SQL query over the index
+revealed it.
+
+The confusion is not the agent's. `match_count` carries two different meanings
+in one response — at the root it counts **symbols** returned, capped by `limit`
+(`src/srclight/server.py:2356`); inside each symbol it counts **matched lines**
+(`src/srclight/db.py:1863`). `match_count: 60` reads as "60 matches found"
+and means "60 symbols, and we stopped".
+
+## Goals
+
+1. An agent can run any srclight tool from a shell, so that a sandbox
+   (context-mode and equivalents) executes it and the bytes never enter the
+   agent's context.
+2. The CLI follows the MCP surface automatically — a tool added to the server
+   appears in the CLI with no further work.
+3. A truncated result says so.
+
+**Governing constraint: additive only.** Nothing existing breaks. No tool,
+field, argument or output shape is renamed, removed or reshaped; every change
+is a new command, a new optional argument, or a new key in a response. A caller
+written against today's srclight must keep working untouched.
+
+## Non-goals
+
+- **`total_matches`.** Knowing the exact count means removing the early exit
+  and running the regex over every symbol's content — seconds on a large repo.
+  `truncated` plus `offset` lets a caller page to the end and learn the total
+  as a by-product, only when it actually needs it.
+- **A `count_only` mode.** It is dangerous precisely because it is convenient:
+  an agent would call it reflexively "just to size the search" and pay the full
+  scan every time. We would be trading a correctness trap for a performance
+  trap. Add it if a real need shows up.
+- **A compact `format: "locations"`.** The chosen consumer is a sandbox, which
+  already keeps volume out of context. This becomes relevant again the day an
+  agent without a sandbox calls the tool directly.
+- **`srclight query` (read-only SQL).** The dispatcher covers the observed
+  need. Making the index schema a public contract is a decision to take on its
+  own merits, not as a passenger.
+
+## Design
+
+### A. `srclight tool` — dynamic dispatch
+
+```bash
+srclight tool --list                       # every tool: name + one-line summary
+srclight tool find_pattern --help          # derived from the tool's JSON Schema
+srclight tool find_pattern --pattern 'this->timer' --kind function --limit 80
+```
+
+**Mechanism.** The command imports `srclight.server`, configures the target
+repo exactly as `serve` does (`src/srclight/cli.py:317-330` — `--workspace`,
+else `--db`, else walk up from the cwd), then dispatches in-process:
+
+```python
+result = asyncio.run(mcp.call_tool(name, arguments))
+click.echo(result.content[0].text)
+```
+
+Verified: `mcp.list_tools()` returns 43 tools, each with `name`, `description`
+and `input_schema` (standard JSON Schema with types, defaults and `required`);
+`mcp.call_tool(name, args)` returns a `CallToolResult` whose
+`content[0].text` is the tool's JSON string.
+
+No running server is required and no per-tool code is written — which is the
+whole point: the CLI is a façade over the same registry the MCP clients see.
+
+**Argument parsing.** Click cannot declare options at runtime on a fixed
+command, so `srclight tool` takes free-form `--key value` pairs and validates
+them against the tool's own `input_schema`:
+
+- `type: string` → passed through
+- `type: integer` / `number` → converted, with a clear error on failure
+- `type: boolean` → `--flag` sets true, `--flag=false` sets false
+- `anyOf: [T, null]` → optional, omitted when absent so the tool's own default
+  applies
+- unknown key, or a missing `required` key → error listing the accepted keys
+
+Validating against the schema rather than a hand-written parser means the CLI
+rejects exactly what an MCP client would reject, with the same wording.
+
+**Output.** The tool's JSON goes to stdout unchanged. Diagnostics go to stderr.
+Exit code is 0 on success, 1 when the tool's JSON carries an `error` key or
+`CallToolResult.isError` is set, 2 on a usage error (unknown tool, bad
+argument). A sandbox can therefore branch on the exit code without parsing.
+
+**Stability.** The CLI names and arguments are the MCP names and arguments, by
+construction. This is a deliberate trade: zero maintenance in exchange for the
+MCP surface becoming a CLI contract. `srclight tool --list` and
+`srclight tool <name> --help` state that the surface tracks the server and may
+change with it.
+
+### B. Truncation that announces itself
+
+Three additions in the `find_pattern` path. Nothing existing is renamed, removed
+or reshaped: a caller written against today's behaviour sees the same results in
+the same keys.
+
+**`truncated`, computed by asking for one more.** `find_pattern_in_symbols`
+scans until it holds `limit + 1` matching symbols. Holding `limit + 1` proves
+more exist: it returns the first `limit` and reports truncation. This is exact,
+not a heuristic, and it preserves the early exit — the extra cost is the scan up
+to *one* further matching symbol.
+
+**`offset`.** A new parameter on both `find_pattern` (so MCP callers get it,
+not only the CLI) and `find_pattern_in_symbols`. It skips the first N matching
+symbols, so a caller that sees `truncated: true` can page. Ordering is already
+deterministic
+(`ORDER BY f.path, s.start_line`, `src/srclight/db.py:1831`), so paging is
+stable as long as the index does not change under it.
+
+**`match_count` is left alone.** An earlier draft renamed the root field to
+`symbols_returned`, on the grounds that a name which means "symbols" while an
+identically named per-symbol field means "lines" is what produced the wrong
+conclusion. That rename is dropped: this change is additive only, and no
+existing field, name or shape moves.
+
+What cost the agent a false conclusion was not the word `match_count` — it was
+that nothing said the list was incomplete. `truncated: true` removes that harm.
+
+**`matched_lines_total` supplies the count the name implies.** `truncated`
+fixes the dangerous failure but leaves a quiet one: an agent reads
+`match_count: 60` at the root, sees `match_count: 3` inside each symbol, and
+writes "60 matches found" when there were 60 symbols and 214 matching lines.
+That error never crashes and nobody notices — the worst kind in an
+agent-facing API.
+
+Adding a synonym (`symbols_returned`) would only move the question: which of
+the two is authoritative? Adding the *missing* count closes it instead. Both
+numbers are present and they differ, so nothing has to be guessed: a reader
+after line counts finds them one key below, and the value is not 60.
+
+It is free — the per-symbol counts are already in hand, and summing them costs
+nothing. When `truncated` is true it is a floor over the symbols returned, not
+a repo-wide total; the docstring says so. That is consistent with refusing
+`count_only`: no code path ever pays the full scan.
+
+Resulting shape — every existing key unchanged, three added:
+
+```json
+{
+  "pattern": "this->timer",
+  "match_count": 60,
+  "matched_lines_total": 214,
+  "truncated": true,
+  "offset": 0,
+  "file_count": 37,
+  "by_file": { "...": [] }
+}
+```
+
+A caller written against today's response keeps working and ignores the new
+keys. The docstring states plainly what each count covers.
+
+## Testing
+
+Both parts are testable without a network and without a running server.
+
+**Dispatcher** — over a small indexed fixture repo, via `CliRunner`:
+
+- `--list` names every tool `mcp.list_tools()` reports, so the two cannot drift
+- a tool added to the registry at test time appears in `--list` without code
+  changes (this is the "follows on its own" claim, and it deserves a test)
+- arguments convert per schema: integer, boolean, nullable-omitted
+- an unknown argument and a missing required one each fail with exit code 2 and
+  name the accepted keys
+- a tool returning an `error` key exits 1
+- stdout is the tool's JSON and nothing else — a sandbox parses it directly
+
+**Truncation** — at the `db.find_pattern_in_symbols` level, where the boundary
+lives:
+
+- more matches than `limit` → exactly `limit` results and `truncated: true`
+- exactly `limit` matches → `truncated: false` (the off-by-one that makes the
+  whole thing pointless if wrong)
+- fewer than `limit` → `truncated: false`
+- `offset` skips the right symbols and stays consistent with a single larger
+  query
+- the scan still stops early: with `limit=1` and many matches, the number of
+  symbols whose content is regex-scanned stays bounded
+- `matched_lines_total` equals the sum of the returned symbols' `match_count`,
+  and differs from the root `match_count` whenever any symbol matched more than
+  one line — the case that makes the two numbers worth distinguishing
+
+**Compatibility** — the constraint deserves its own test, or it erodes:
+
+- the same query, before and after, returns identical results in identical keys;
+  the response gains `truncated` and `offset` and loses nothing
+- `find_pattern` called with exactly today's arguments behaves as it does today
+
+## Risks
+
+**The MCP surface becomes a CLI contract.** Accepted knowingly. Renaming an MCP
+tool or one of its arguments is now also a CLI break. The mitigation is
+honesty, not machinery: say so in `--help`.
+
+**`offset` paging is not snapshot-isolated.** A reindex between two pages can
+shift results. Acceptable for a search tool; worth a sentence in the docstring
+rather than a transaction.
+
+**In-process import cost.** `srclight tool` pays the server module's import on
+every invocation. Tolerable for a sandbox that runs it a handful of times; if it
+becomes a problem, the answer is batching in the sandbox, not a daemon.

--- a/src/srclight/cli.py
+++ b/src/srclight/cli.py
@@ -390,6 +390,10 @@ def tool(ctx: click.Context, tool_name: str | None, list_tools_flag: bool,
         parse_cli_pairs,
     )
 
+    if tool_name in ("--help", "-h"):
+        click.echo(ctx.get_help())
+        ctx.exit(0)
+
     tools = asyncio.run(mcp.list_tools())
     by_name = {t.name: t for t in tools}
 
@@ -405,6 +409,15 @@ def tool(ctx: click.Context, tool_name: str | None, list_tools_flag: bool,
         hint = f" Did you mean: {', '.join(close)}?" if close else ""
         click.echo(f"Error: unknown tool '{tool_name}'.{hint} "
                    f"Run 'srclight tool --list' to see all tools.", err=True)
+        sys.exit(2)
+
+    if tool_name == "restart_server":
+        click.echo(
+            "Error: 'restart_server' only makes sense against a long-lived SSE "
+            "server process; a one-shot CLI invocation has nothing left to "
+            "restart into. Run it over MCP against a running 'srclight serve' "
+            "instead.", err=True,
+        )
         sys.exit(2)
 
     if "--help" in ctx.args or "-h" in ctx.args:
@@ -426,7 +439,18 @@ def tool(ctx: click.Context, tool_name: str | None, list_tools_flag: bool,
         root = _find_repo_root(Path.cwd())
         configure(db_path=_get_db_path(root), repo_root=root)
 
-    result = asyncio.run(mcp.call_tool(spec.name, arguments))
+    try:
+        result = asyncio.run(mcp.call_tool(spec.name, arguments))
+    except Exception as e:
+        # mcp.call_tool() raises rather than returning an isError result, so
+        # this is the only path most tool failures take (missing index, bad
+        # --db, unknown workspace, ...). Keep stdout as JSON per the
+        # documented contract even here, so a sandbox parsing stdout never
+        # has to special-case the error path.
+        click.echo(json.dumps({"error": f"{type(e).__name__}: {e}"}))
+        click.echo(f"Error: tool '{spec.name}' failed: {e}", err=True)
+        sys.exit(1)
+
     text = "\n".join(
         block.text for block in result.content if getattr(block, "text", None) is not None
     )
@@ -435,10 +459,11 @@ def tool(ctx: click.Context, tool_name: str | None, list_tools_flag: bool,
     if getattr(result, "isError", False):
         sys.exit(1)
     try:
-        if isinstance(json.loads(text), dict) and "error" in json.loads(text):
-            sys.exit(1)
+        parsed = json.loads(text)
     except json.JSONDecodeError:
-        pass
+        parsed = None
+    if isinstance(parsed, dict) and "error" in parsed:
+        sys.exit(1)
 
 
 # --- Workspace commands ---

--- a/src/srclight/cli.py
+++ b/src/srclight/cli.py
@@ -358,6 +358,89 @@ def serve(db_path: str | None, workspace_name: str | None, transport: str, port:
     run_server(transport=transport, port=port)
 
 
+@main.command(
+    "tool",
+    add_help_option=False,          # so `tool <name> --help` reaches the tool
+    context_settings={"ignore_unknown_options": True, "allow_extra_args": True},
+)
+@click.argument("tool_name", required=False)
+@click.option("--list", "list_tools_flag", is_flag=True, help="List every available tool")
+@click.option("--db", "db_path", type=click.Path(), help="Database path")
+@click.option("--workspace", "-w", "workspace_name", help="Workspace name (multi-repo mode)")
+@click.pass_context
+def tool(ctx: click.Context, tool_name: str | None, list_tools_flag: bool,
+         db_path: str | None, workspace_name: str | None):
+    """Run any MCP tool from the shell.
+
+    The tools, their arguments and their help text come from the running
+    server's own registry, so this command tracks the MCP surface exactly —
+    including across upgrades, which means a tool renamed there is renamed
+    here too.
+
+    Output is the tool's JSON on stdout and nothing else. Exit codes: 0 on
+    success, 1 when the tool reports an error, 2 on a usage error.
+    """
+    import asyncio
+
+    from .server import configure, configure_workspace, mcp
+    from .tool_dispatch import (
+        ToolArgumentError,
+        coerce_arguments,
+        format_tool_help,
+        parse_cli_pairs,
+    )
+
+    tools = asyncio.run(mcp.list_tools())
+    by_name = {t.name: t for t in tools}
+
+    if list_tools_flag or not tool_name:
+        for name in sorted(by_name):
+            summary = (by_name[name].description or "").strip().split("\n")[0]
+            click.echo(f"{name}  {summary}")
+        return
+
+    spec = by_name.get(tool_name)
+    if spec is None:
+        close = [n for n in sorted(by_name) if n.startswith(tool_name[:4])]
+        hint = f" Did you mean: {', '.join(close)}?" if close else ""
+        click.echo(f"Error: unknown tool '{tool_name}'.{hint} "
+                   f"Run 'srclight tool --list' to see all tools.", err=True)
+        sys.exit(2)
+
+    if "--help" in ctx.args or "-h" in ctx.args:
+        click.echo(format_tool_help(spec.name, spec.description or "", spec.input_schema))
+        return
+
+    try:
+        arguments = coerce_arguments(spec.input_schema, parse_cli_pairs(list(ctx.args)))
+    except ToolArgumentError as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(2)
+
+    if workspace_name:
+        configure_workspace(workspace_name)
+    elif db_path:
+        db_file = Path(db_path).resolve()
+        configure(db_path=db_file, repo_root=_find_repo_root(db_file.parent))
+    else:
+        root = _find_repo_root(Path.cwd())
+        configure(db_path=_get_db_path(root), repo_root=root)
+
+    result = asyncio.run(mcp.call_tool(spec.name, arguments))
+    text = "\n".join(
+        block.text for block in result.content if getattr(block, "text", None) is not None
+    )
+    click.echo(text)
+
+    if getattr(result, "isError", False):
+        sys.exit(1)
+    try:
+        if isinstance(json.loads(text), dict) and "error" in json.loads(text):
+            sys.exit(1)
+    except json.JSONDecodeError:
+        pass
+
+
 # --- Workspace commands ---
 
 

--- a/src/srclight/db.py
+++ b/src/srclight/db.py
@@ -1799,6 +1799,7 @@ class Database:
         language: str | None = None,
         kind: str | None = None,
         limit: int = 50,
+        offset: int = 0,
     ) -> list[dict[str, Any]]:
         """Search for a regex pattern within symbol source code.
 
@@ -1807,6 +1808,9 @@ class Database:
         Each result carries ``match_count`` (how many lines in the symbol matched)
         and ``matched_lines`` — per matching line, its offset within the symbol,
         its absolute file line, the line text, and the substring the pattern hit.
+        ``offset`` skips that many matching symbols before collecting, so a
+        caller that was truncated can page. Ordering is stable (path, then
+        start line) as long as the index does not change between calls.
         """
         assert self.conn is not None
 
@@ -1832,6 +1836,7 @@ class Database:
 
         compiled = re.compile(pattern)
         results: list[dict[str, Any]] = []
+        seen = 0  # matching symbols passed over, including those skipped by offset
 
         for row in self.conn.execute(sql, params):
             content = row["content"]
@@ -1851,6 +1856,9 @@ class Database:
                     })
 
             if matched_lines:
+                seen += 1
+                if seen <= offset:
+                    continue
                 sym = self._row_to_symbol(row)
                 results.append({
                     "name": sym.name,

--- a/src/srclight/server.py
+++ b/src/srclight/server.py
@@ -2335,6 +2335,12 @@ def find_pattern(
     except _re.error as e:
         return json.dumps({"error": f"Invalid regex pattern: {e}"}, indent=2)
 
+    # Clamp before use: a negative limit would otherwise make `limit + 1`
+    # below request 0 or fewer rows while `len(matches) > limit` stays true
+    # for any non-negative match count, reporting `truncated: true` with 0
+    # results.
+    limit = max(0, limit)
+
     if _is_workspace_mode():
         if not project:
             return _project_required_error("find_pattern")

--- a/src/srclight/server.py
+++ b/src/srclight/server.py
@@ -2289,6 +2289,7 @@ def find_pattern(
     language: str | None = None,
     kind: str | None = None,
     limit: int = 50,
+    offset: int = 0,
 ) -> str:
     """Search for structural code patterns in symbol bodies.
 
@@ -2300,6 +2301,13 @@ def find_pattern(
     - The symbol name and kind containing the match
     - File path and line numbers of the symbol
     - The match context within the symbol
+
+    The response reports three counts, and they mean different things:
+    `match_count` is how many SYMBOLS are returned (capped by `limit`),
+    `matched_lines_total` is how many LINES matched inside them, and
+    `truncated` says whether more symbols existed beyond `limit`. When
+    `truncated` is true, `matched_lines_total` is a floor over what was
+    returned, not a repo-wide total — nothing here ever scans the whole index.
 
     Pattern supports regex. Common patterns:
     - "Color\\\\(0x" — find raw color literals
@@ -2315,6 +2323,9 @@ def find_pattern(
         language: Filter by language (e.g., 'python', 'javascript')
         kind: Filter by symbol kind (e.g., 'function', 'method')
         limit: Maximum results (default 50)
+        offset: Skip this many matching symbols before collecting (default 0).
+            With `truncated`, this pages through a result set larger than
+            `limit`.
     """
     import re as _re
 
@@ -2337,11 +2348,21 @@ def find_pattern(
             return json.dumps({"error": f"Project '{project}' not indexed"})
         db = Database(db_path)
         db.open()
-        matches = db.find_pattern_in_symbols(pattern, language=language, kind=kind, limit=limit)
+        matches = db.find_pattern_in_symbols(
+            pattern, language=language, kind=kind, limit=limit + 1, offset=offset
+        )
         db.close()
     else:
         db = _get_db()
-        matches = db.find_pattern_in_symbols(pattern, language=language, kind=kind, limit=limit)
+        matches = db.find_pattern_in_symbols(
+            pattern, language=language, kind=kind, limit=limit + 1, offset=offset
+        )
+
+    # Asking for limit + 1 is how truncation is detected: holding one more than
+    # requested proves more exist. Exact, and the scan still stops early.
+    truncated = len(matches) > limit
+    matches = matches[:limit]
+    matched_lines_total = sum(m["match_count"] for m in matches)
 
     # Group by file for readability
     by_file: dict[str, list[dict]] = {}
@@ -2352,6 +2373,9 @@ def find_pattern(
     result: dict[str, object] = {
         "pattern": pattern,
         "match_count": len(matches),
+        "matched_lines_total": matched_lines_total,
+        "truncated": truncated,
+        "offset": offset,
         "file_count": len(by_file),
         "by_file": by_file,
     }

--- a/src/srclight/tool_dispatch.py
+++ b/src/srclight/tool_dispatch.py
@@ -1,0 +1,146 @@
+"""Turn shell tokens into typed MCP tool arguments.
+
+The CLI dispatches to tools it has never heard of, so it cannot declare
+options ahead of time. It reads each tool's JSON Schema instead — the same
+schema an MCP client validates against — which is why a tool added to the
+server needs no CLI change, and why a rejected argument is rejected here for
+the same reason and in the same words it would be over MCP.
+
+Deliberately free of Click, MCP and I/O: this is the fiddly part, and it is
+worth being able to test it on its own.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_TRUE = {"true", "1", "yes", "on"}
+_FALSE = {"false", "0", "no", "off"}
+
+
+class ToolArgumentError(Exception):
+    """A usage error whose message is meant for the person who typed it."""
+
+
+def parse_cli_pairs(tokens: list[str]) -> dict[str, str]:
+    """Turn ``["--key", "value", "--flag"]`` into ``{"key": "value", "flag": "true"}``.
+
+    A bare ``--flag`` (nothing after it, or another option next) reads as
+    "true" so boolean arguments behave the way a shell user expects. Dashes in
+    names become underscores, since MCP argument names are snake_case.
+    """
+    pairs: dict[str, str] = {}
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        if not token.startswith("--"):
+            raise ToolArgumentError(
+                f"unexpected argument {token!r}: pass tool arguments as --name value"
+            )
+        body = token[2:]
+        if "=" in body:
+            name, value = body.split("=", 1)
+            i += 1
+        else:
+            name = body
+            nxt = tokens[i + 1] if i + 1 < len(tokens) else None
+            # "--limit -1": a lone dash-number is a value, not an option.
+            if nxt is not None and (not nxt.startswith("--")):
+                value = nxt
+                i += 2
+            else:
+                value = "true"
+                i += 1
+        pairs[name.replace("-", "_")] = value
+    return pairs
+
+
+def _accepted_types(prop: dict[str, Any]) -> set[str]:
+    """The JSON Schema types a property accepts, ignoring null."""
+    if "type" in prop:
+        return {prop["type"]}
+    types = set()
+    for branch in prop.get("anyOf", []):
+        if isinstance(branch, dict) and "type" in branch:
+            types.add(branch["type"])
+    types.discard("null")
+    return types
+
+
+def coerce_arguments(schema: dict[str, Any], raw: dict[str, str]) -> dict[str, object]:
+    """Convert string values to the types the schema declares.
+
+    Omitted optionals are left out rather than filled in, so the tool's own
+    defaults apply — restating them here would freeze them at the value they
+    had the day this was written.
+    """
+    properties: dict[str, Any] = schema.get("properties", {})
+    required: list[str] = list(schema.get("required", []))
+
+    unknown = sorted(set(raw) - set(properties))
+    if unknown:
+        accepted = ", ".join(f"--{name}" for name in sorted(properties))
+        raise ToolArgumentError(
+            f"unknown argument(s): {', '.join(unknown)}. Accepted: {accepted or '(none)'}"
+        )
+
+    missing = [name for name in required if name not in raw]
+    if missing:
+        raise ToolArgumentError(f"missing required argument(s): {', '.join(missing)}")
+
+    out: dict[str, object] = {}
+    for name, value in raw.items():
+        types = _accepted_types(properties[name])
+        if "integer" in types:
+            try:
+                out[name] = int(value)
+            except ValueError:
+                raise ToolArgumentError(
+                    f"--{name} expects an integer, got {value!r}"
+                ) from None
+        elif "number" in types:
+            try:
+                out[name] = float(value)
+            except ValueError:
+                raise ToolArgumentError(
+                    f"--{name} expects a number, got {value!r}"
+                ) from None
+        elif "boolean" in types:
+            lowered = value.strip().lower()
+            if lowered in _TRUE:
+                out[name] = True
+            elif lowered in _FALSE:
+                out[name] = False
+            else:
+                raise ToolArgumentError(
+                    f"--{name} expects true or false, got {value!r}"
+                )
+        else:
+            out[name] = value
+    return out
+
+
+def format_tool_help(name: str, description: str, schema: dict[str, Any]) -> str:
+    """Render a tool's usage from its schema, in the shape of --help output."""
+    properties: dict[str, Any] = schema.get("properties", {})
+    required: set[str] = set(schema.get("required", []))
+
+    summary = (description or "").strip().split("\n\n")[0].strip()
+    lines = [f"Usage: srclight tool {name} [ARGUMENTS]", ""]
+    if summary:
+        lines += [summary, ""]
+    if not properties:
+        lines.append("This tool takes no arguments.")
+        return "\n".join(lines)
+
+    lines.append("Arguments:")
+    for arg in sorted(properties):
+        prop = properties[arg]
+        types = _accepted_types(prop) or {"string"}
+        kind = "|".join(sorted(types))
+        if arg in required:
+            note = "required"
+        else:
+            note = f"default: {prop.get('default')!r}"
+        lines.append(f"  --{arg} <{kind}>  ({note})")
+    return "\n".join(lines)

--- a/src/srclight/tool_dispatch.py
+++ b/src/srclight/tool_dispatch.py
@@ -115,9 +115,39 @@ def coerce_arguments(schema: dict[str, Any], raw: dict[str, str]) -> dict[str, o
                 raise ToolArgumentError(
                     f"--{name} expects true or false, got {value!r}"
                 )
+        elif "array" in types:
+            items_type = _array_item_type(properties[name])
+            if items_type is not None and items_type != "string":
+                raise ToolArgumentError(
+                    f"--{name} is a list of {items_type}, which cannot be "
+                    f"expressed on the command line"
+                )
+            out[name] = [item.strip() for item in value.split(",")]
+        elif "object" in types:
+            # No non-scalar besides array exists in the registry today, but
+            # an object would have no command-line spelling either.
+            raise ToolArgumentError(
+                f"--{name} is an object, which cannot be expressed on the command line"
+            )
         else:
             out[name] = value
     return out
+
+
+def _array_item_type(prop: dict[str, Any]) -> str | None:
+    """The declared ``items.type`` of an array-typed property, if any."""
+    if prop.get("type") == "array":
+        items = prop.get("items")
+        if isinstance(items, dict):
+            return items.get("type")
+        return None
+    for branch in prop.get("anyOf", []):
+        if isinstance(branch, dict) and branch.get("type") == "array":
+            items = branch.get("items")
+            if isinstance(items, dict):
+                return items.get("type")
+            return None
+    return None
 
 
 def format_tool_help(name: str, description: str, schema: dict[str, Any]) -> str:
@@ -129,6 +159,11 @@ def format_tool_help(name: str, description: str, schema: dict[str, Any]) -> str
     lines = [f"Usage: srclight tool {name} [ARGUMENTS]", ""]
     if summary:
         lines += [summary, ""]
+    lines.append(
+        "Arguments are derived from the running server's schema for this "
+        "tool and may change as that schema changes."
+    )
+    lines.append("")
     if not properties:
         lines.append("This tool takes no arguments.")
         return "\n".join(lines)
@@ -137,7 +172,11 @@ def format_tool_help(name: str, description: str, schema: dict[str, Any]) -> str
     for arg in sorted(properties):
         prop = properties[arg]
         types = _accepted_types(prop) or {"string"}
-        kind = "|".join(sorted(types))
+        if "array" in types:
+            item_type = _array_item_type(prop) or "string"
+            kind = f"comma-separated {item_type} list"
+        else:
+            kind = "|".join(sorted(types))
         if arg in required:
             note = "required"
         else:

--- a/tests/test_new_tools.py
+++ b/tests/test_new_tools.py
@@ -596,3 +596,99 @@ class TestLuaCommentImports:
     def test_a_method_named_require_is_not_an_import(self):
         """`self.require(...)` belongs to some table, not to the loader."""
         assert _extract_imports('local m = self.require("notmine")', "lua") == []
+
+
+class TestFindPatternTruncation:
+    """find_pattern must say when its list is incomplete."""
+
+    def _configure(self, db, tmp_path, monkeypatch):
+        from srclight import server as server_mod
+        monkeypatch.setattr(server_mod, "_workspace_name", None)
+        monkeypatch.setattr(server_mod, "_db", db)
+        monkeypatch.setattr(server_mod, "_db_path", tmp_path / "test.db")
+        monkeypatch.setattr(server_mod, "_repo_root", tmp_path)
+        return server_mod
+
+    def test_more_matches_than_limit_reports_truncated(self, db, tmp_path, monkeypatch):
+        import json
+        server_mod = self._configure(db, tmp_path, monkeypatch)
+        fid = _insert_file(db)
+        for i in range(5):
+            _insert_symbol(db, fid, f"fn_{i}", start_line=i * 5 + 1, end_line=i * 5 + 3,
+                           content=f"def fn_{i}():\n    # TODO: item {i}")
+        db.commit()
+
+        result = json.loads(server_mod.find_pattern("TODO", limit=3))
+
+        assert result["match_count"] == 3
+        assert result["truncated"] is True
+
+    def test_exactly_limit_matches_is_not_truncated(self, db, tmp_path, monkeypatch):
+        """The off-by-one that makes the whole feature pointless if wrong."""
+        import json
+        server_mod = self._configure(db, tmp_path, monkeypatch)
+        fid = _insert_file(db)
+        for i in range(3):
+            _insert_symbol(db, fid, f"fn_{i}", start_line=i * 5 + 1, end_line=i * 5 + 3,
+                           content=f"def fn_{i}():\n    # TODO: item {i}")
+        db.commit()
+
+        result = json.loads(server_mod.find_pattern("TODO", limit=3))
+
+        assert result["match_count"] == 3
+        assert result["truncated"] is False
+
+    def test_fewer_matches_than_limit_is_not_truncated(self, db, tmp_path, monkeypatch):
+        import json
+        server_mod = self._configure(db, tmp_path, monkeypatch)
+        fid = _insert_file(db)
+        _insert_symbol(db, fid, "only", content="def only():\n    # TODO: x")
+        db.commit()
+
+        result = json.loads(server_mod.find_pattern("TODO", limit=50))
+
+        assert result["truncated"] is False
+
+    def test_matched_lines_total_counts_lines_not_symbols(self, db, tmp_path, monkeypatch):
+        """The count the root match_count's name implies but does not hold."""
+        import json
+        server_mod = self._configure(db, tmp_path, monkeypatch)
+        fid = _insert_file(db)
+        _insert_symbol(db, fid, "two_hits", start_line=1, end_line=4,
+                       content="def two_hits():\n    # TODO: a\n    # TODO: b")
+        _insert_symbol(db, fid, "one_hit", start_line=10, end_line=12,
+                       content="def one_hit():\n    # TODO: c")
+        db.commit()
+
+        result = json.loads(server_mod.find_pattern("TODO", limit=50))
+
+        assert result["match_count"] == 2            # symbols
+        assert result["matched_lines_total"] == 3    # lines
+
+    def test_offset_is_echoed_and_pages(self, db, tmp_path, monkeypatch):
+        import json
+        server_mod = self._configure(db, tmp_path, monkeypatch)
+        fid = _insert_file(db)
+        for i in range(5):
+            _insert_symbol(db, fid, f"fn_{i}", start_line=i * 5 + 1, end_line=i * 5 + 3,
+                           content=f"def fn_{i}():\n    # TODO: item {i}")
+        db.commit()
+
+        page = json.loads(server_mod.find_pattern("TODO", limit=3, offset=3))
+
+        assert page["offset"] == 3
+        assert page["match_count"] == 2
+        assert page["truncated"] is False
+
+    def test_existing_keys_are_untouched(self, db, tmp_path, monkeypatch):
+        """The additive-only constraint, asserted rather than assumed."""
+        import json
+        server_mod = self._configure(db, tmp_path, monkeypatch)
+        fid = _insert_file(db)
+        _insert_symbol(db, fid, "only", content="def only():\n    # TODO: x")
+        db.commit()
+
+        result = json.loads(server_mod.find_pattern("TODO"))
+
+        assert {"pattern", "match_count", "file_count", "by_file"} <= set(result)
+        assert result["by_file"]["src/main.py"][0]["name"] == "only"

--- a/tests/test_new_tools.py
+++ b/tests/test_new_tools.py
@@ -226,6 +226,34 @@ class TestFindPattern:
         results = db.find_pattern_in_symbols(r"except\s+\w+\s+as\s+\w+")
         assert len(results) == 1
 
+    def test_offset_skips_leading_matches(self, db):
+        """offset skips matching symbols without disturbing the order."""
+        fid = _insert_file(db)
+        for i in range(10):
+            _insert_symbol(db, fid, f"fn_{i}", start_line=i * 5 + 1, end_line=i * 5 + 3,
+                           content=f"def fn_{i}():\n    # TODO: item {i}")
+        db.commit()
+
+        everything = db.find_pattern_in_symbols("TODO", limit=10)
+        skipped = db.find_pattern_in_symbols("TODO", limit=10, offset=3)
+
+        assert [r["name"] for r in skipped] == [r["name"] for r in everything[3:]]
+
+    def test_offset_past_the_end_returns_nothing(self, db):
+        fid = _insert_file(db)
+        _insert_symbol(db, fid, "only", content="def only():\n    # TODO: x")
+        db.commit()
+
+        assert db.find_pattern_in_symbols("TODO", offset=5) == []
+
+    def test_offset_defaults_to_zero(self, db):
+        """The existing call signature keeps its exact behaviour."""
+        fid = _insert_file(db)
+        _insert_symbol(db, fid, "only", content="def only():\n    # TODO: x")
+        db.commit()
+
+        assert len(db.find_pattern_in_symbols("TODO")) == 1
+
 
 # --- find_imports tests ---
 

--- a/tests/test_new_tools.py
+++ b/tests/test_new_tools.py
@@ -680,6 +680,68 @@ class TestFindPatternTruncation:
         assert page["match_count"] == 2
         assert page["truncated"] is False
 
+    def test_scan_stops_once_limit_is_reached(self, db, tmp_path, monkeypatch):
+        """The row scan must stay bounded even when almost everything matches.
+
+        If a future change collected every matching symbol into a list
+        before slicing to `limit` (instead of breaking out of the database
+        cursor loop as soon as enough results are found), this would fail:
+        `scanned["n"]` would climb toward the full 500 inserted symbols
+        instead of staying near `limit`. That is the "nothing here ever
+        scans the whole index" promise in `find_pattern`'s docstring.
+        """
+        import json
+
+        from srclight import db as db_mod
+        server_mod = self._configure(db, tmp_path, monkeypatch)
+        fid = _insert_file(db)
+        for i in range(500):
+            _insert_symbol(db, fid, f"fn_{i}", start_line=i * 3 + 1, end_line=i * 3 + 2,
+                           content=f"def fn_{i}():\n    # TODO: item {i}")
+        db.commit()
+
+        scanned = {"n": 0}
+        original = db_mod.Database._row_to_symbol
+
+        def counting(self, row):
+            scanned["n"] += 1
+            return original(self, row)
+
+        monkeypatch.setattr(db_mod.Database, "_row_to_symbol", counting)
+
+        result = json.loads(server_mod.find_pattern("TODO", limit=1))
+
+        assert result["match_count"] == 1
+        assert result["truncated"] is True
+        # Every one of the 500 symbols matches, so if the scan were
+        # unbounded this would be 500, not a handful.
+        assert scanned["n"] <= 5
+
+    def test_truncated_is_exact_when_offset_is_nonzero(self, db, tmp_path, monkeypatch):
+        """`truncated` must reflect what's left *after* `offset`, not just `limit`.
+
+        This is the seam between paging (`offset`) and truncation detection
+        (`limit + 1`): a page in the middle of a result set must report
+        `truncated: true` when more rows remain beyond it, and the final
+        page must report `truncated: false` even though `offset > 0`. Prior
+        coverage only exercised offset with a final, exactly-fitting page.
+        """
+        import json
+        server_mod = self._configure(db, tmp_path, monkeypatch)
+        fid = _insert_file(db)
+        for i in range(5):
+            _insert_symbol(db, fid, f"fn_{i}", start_line=i * 5 + 1, end_line=i * 5 + 3,
+                           content=f"def fn_{i}():\n    # TODO: item {i}")
+        db.commit()
+
+        middle_page = json.loads(server_mod.find_pattern("TODO", limit=2, offset=1))
+        assert middle_page["match_count"] == 2
+        assert middle_page["truncated"] is True  # 2 more (indices 3, 4) remain
+
+        final_page = json.loads(server_mod.find_pattern("TODO", limit=2, offset=3))
+        assert final_page["match_count"] == 2
+        assert final_page["truncated"] is False  # nothing left after this page
+
     def test_existing_keys_are_untouched(self, db, tmp_path, monkeypatch):
         """The additive-only constraint, asserted rather than assumed."""
         import json

--- a/tests/test_tool_dispatch.py
+++ b/tests/test_tool_dispatch.py
@@ -99,3 +99,121 @@ class TestFormatToolHelp:
         assert "find_pattern" in text
         assert "--pattern" in text and "required" in text
         assert "--limit" in text and "50" in text
+
+
+class TestToolCommand:
+    """The CLI face of the MCP registry."""
+
+    def _repo(self, tmp_path):
+        (tmp_path / "main.py").write_text(
+            "def alpha():\n    # TODO: one\n    pass\n\n\n"
+            "def beta():\n    # TODO: two\n    pass\n"
+        )
+        from click.testing import CliRunner
+        from srclight.cli import main
+        result = CliRunner().invoke(main, ["index", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        return tmp_path
+
+    def test_list_names_every_registered_tool(self):
+        import asyncio
+        from click.testing import CliRunner
+        from srclight.cli import main
+        from srclight.server import mcp
+
+        registered = {t.name for t in asyncio.run(mcp.list_tools())}
+
+        result = CliRunner().invoke(main, ["tool", "--list"])
+
+        assert result.exit_code == 0, result.output
+        listed = {line.split()[0] for line in result.output.splitlines() if line.strip()}
+        assert registered <= listed, f"missing from --list: {registered - listed}"
+
+    def test_a_newly_registered_tool_appears_without_code_changes(self, monkeypatch):
+        """The 'it follows on its own' claim, asserted rather than believed."""
+        from click.testing import CliRunner
+        from srclight.cli import main
+        from srclight.server import mcp
+
+        @mcp.tool()
+        def a_tool_invented_by_a_test() -> str:
+            """Invented at test time."""
+            return "{}"
+
+        try:
+            result = CliRunner().invoke(main, ["tool", "--list"])
+            assert "a_tool_invented_by_a_test" in result.output
+        finally:
+            mcp.remove_tool("a_tool_invented_by_a_test")
+
+    def test_tool_help_comes_from_the_schema(self):
+        from click.testing import CliRunner
+        from srclight.cli import main
+
+        result = CliRunner().invoke(main, ["tool", "find_pattern", "--help"])
+
+        assert result.exit_code == 0, result.output
+        assert "--pattern" in result.output and "required" in result.output
+
+    def test_dispatch_returns_the_tools_json_on_stdout(self, tmp_path):
+        import json
+        from click.testing import CliRunner
+        from srclight.cli import main
+        repo = self._repo(tmp_path)
+
+        result = CliRunner().invoke(
+            main, ["tool", "--db", str(repo / ".srclight" / "index.db"),
+                   "find_pattern", "--pattern", "TODO", "--limit", "1"]
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)     # stdout is JSON and nothing else
+        assert payload["match_count"] == 1
+        assert payload["truncated"] is True
+
+    def test_unknown_tool_exits_two_and_suggests(self):
+        from click.testing import CliRunner
+        from srclight.cli import main
+
+        result = CliRunner().invoke(main, ["tool", "find_paterns"])
+
+        assert result.exit_code == 2
+        assert "find_paterns" in result.output
+
+    def test_unknown_argument_exits_two(self, tmp_path):
+        from click.testing import CliRunner
+        from srclight.cli import main
+        repo = self._repo(tmp_path)
+
+        result = CliRunner().invoke(
+            main, ["tool", "--db", str(repo / ".srclight" / "index.db"),
+                   "find_pattern", "--pattern", "TODO", "--patern", "typo"]
+        )
+
+        assert result.exit_code == 2
+        assert "patern" in result.output
+
+    def test_missing_required_argument_exits_two(self, tmp_path):
+        from click.testing import CliRunner
+        from srclight.cli import main
+        repo = self._repo(tmp_path)
+
+        result = CliRunner().invoke(
+            main, ["tool", "--db", str(repo / ".srclight" / "index.db"), "find_pattern"]
+        )
+
+        assert result.exit_code == 2
+        assert "pattern" in result.output
+
+    def test_a_tool_error_exits_one(self, tmp_path):
+        from click.testing import CliRunner
+        from srclight.cli import main
+        repo = self._repo(tmp_path)
+
+        result = CliRunner().invoke(
+            main, ["tool", "--db", str(repo / ".srclight" / "index.db"),
+                   "find_pattern", "--pattern", "([unclosed"]
+        )
+
+        assert result.exit_code == 1
+        assert "error" in result.output

--- a/tests/test_tool_dispatch.py
+++ b/tests/test_tool_dispatch.py
@@ -1,0 +1,101 @@
+"""Turning shell tokens into typed MCP tool arguments."""
+
+import pytest
+
+from srclight.tool_dispatch import (
+    ToolArgumentError,
+    coerce_arguments,
+    format_tool_help,
+    parse_cli_pairs,
+)
+
+# The real shape, copied from mcp.list_tools() for find_pattern.
+FIND_PATTERN_SCHEMA = {
+    "type": "object",
+    "title": "find_patternArguments",
+    "required": ["pattern"],
+    "properties": {
+        "pattern": {"title": "Pattern", "type": "string"},
+        "project": {"anyOf": [{"type": "string"}, {"type": "null"}],
+                    "default": None, "title": "Project"},
+        "limit": {"default": 50, "title": "Limit", "type": "integer"},
+        "verbose": {"default": False, "title": "Verbose", "type": "boolean"},
+    },
+}
+
+
+class TestParseCliPairs:
+    def test_separate_value(self):
+        assert parse_cli_pairs(["--pattern", "TODO"]) == {"pattern": "TODO"}
+
+    def test_equals_form(self):
+        assert parse_cli_pairs(["--pattern=TODO"]) == {"pattern": "TODO"}
+
+    def test_dashes_become_underscores(self):
+        assert parse_cli_pairs(["--symbol-name", "x"]) == {"symbol_name": "x"}
+
+    def test_bare_flag_is_true(self):
+        assert parse_cli_pairs(["--verbose"]) == {"verbose": "true"}
+
+    def test_bare_flag_before_another_flag(self):
+        assert parse_cli_pairs(["--verbose", "--limit", "5"]) == {
+            "verbose": "true", "limit": "5",
+        }
+
+    def test_value_may_look_negative(self):
+        assert parse_cli_pairs(["--limit", "-1"]) == {"limit": "-1"}
+
+    def test_a_bare_word_is_rejected(self):
+        with pytest.raises(ToolArgumentError) as e:
+            parse_cli_pairs(["pattern", "TODO"])
+        assert "pattern" in str(e.value)
+
+
+class TestCoerceArguments:
+    def test_string_passes_through(self):
+        out = coerce_arguments(FIND_PATTERN_SCHEMA, {"pattern": "TODO"})
+        assert out == {"pattern": "TODO"}
+
+    def test_integer_is_converted(self):
+        out = coerce_arguments(FIND_PATTERN_SCHEMA, {"pattern": "x", "limit": "80"})
+        assert out["limit"] == 80
+
+    def test_bad_integer_is_reported_with_the_key(self):
+        with pytest.raises(ToolArgumentError) as e:
+            coerce_arguments(FIND_PATTERN_SCHEMA, {"pattern": "x", "limit": "many"})
+        assert "limit" in str(e.value)
+
+    def test_boolean_accepts_both_spellings(self):
+        assert coerce_arguments(FIND_PATTERN_SCHEMA,
+                                {"pattern": "x", "verbose": "true"})["verbose"] is True
+        assert coerce_arguments(FIND_PATTERN_SCHEMA,
+                                {"pattern": "x", "verbose": "false"})["verbose"] is False
+
+    def test_nullable_string_is_accepted(self):
+        out = coerce_arguments(FIND_PATTERN_SCHEMA, {"pattern": "x", "project": "alpha"})
+        assert out["project"] == "alpha"
+
+    def test_omitted_optionals_are_left_out(self):
+        """The tool's own defaults must apply — we do not restate them."""
+        out = coerce_arguments(FIND_PATTERN_SCHEMA, {"pattern": "x"})
+        assert out == {"pattern": "x"}
+
+    def test_missing_required_names_the_key(self):
+        with pytest.raises(ToolArgumentError) as e:
+            coerce_arguments(FIND_PATTERN_SCHEMA, {})
+        assert "pattern" in str(e.value)
+
+    def test_unknown_key_lists_what_is_accepted(self):
+        with pytest.raises(ToolArgumentError) as e:
+            coerce_arguments(FIND_PATTERN_SCHEMA, {"pattern": "x", "patern": "typo"})
+        message = str(e.value)
+        assert "patern" in message and "pattern" in message
+
+
+class TestFormatToolHelp:
+    def test_help_shows_arguments_types_and_requiredness(self):
+        text = format_tool_help("find_pattern", "Search for structural patterns.",
+                                FIND_PATTERN_SCHEMA)
+        assert "find_pattern" in text
+        assert "--pattern" in text and "required" in text
+        assert "--limit" in text and "50" in text


### PR DESCRIPTION
## Problem

`find_pattern` searches inside parsed symbol bodies rather than raw text — which
is what makes it useful, and also what makes its answers large. On a 3 100-file
C codebase it failed an agent twice over.

**It overflowed.** Every match carries its containing symbol and every matching
line in full. Four real queries from one session: 161 870 characters, 74 654,
and two around 10k tokens. When a response overflows, the harness spills it to a
file and requires reading it back — so the context is paid twice. That session
ended up querying `.srclight/index.db` in SQL from a sandbox, which is the
clearest possible signal that the tool surface was missing something.

**It truncated in silence.** `find_pattern_in_symbols` stopped at `limit` with no
signal. The agent got `match_count: 60` with `limit: 60`, concluded the sweep had
converged, and was wrong — a matching symbol was missing from the list, and only
a separate SQL query revealed it.

The confusion was not the agent's fault: `match_count` means two different things
in one response. At the root it counts **symbols** returned, capped by `limit`;
inside each symbol it counts **matched lines**. `match_count: 60` reads as
"60 matches found" and means "60 symbols, and we stopped".

## What this adds

**`srclight tool`** — any MCP tool, from a shell:

```bash
srclight tool --list                    # all 43, with a one-line summary
srclight tool find_pattern --help       # arguments, from the tool's own schema
srclight tool find_pattern --pattern 'this->timer' --kind function --limit 80
```

It dispatches in-process by reading the server's own registry (`list_tools()` /
`call_tool()`) and derives each argument from that tool's JSON Schema — so a tool
added to the MCP server appears here with no CLI change. A test asserts exactly
that, by registering a tool at test time and finding it in `--list`.

stdout is the tool's JSON and nothing else, so it pipes; diagnostics go to
stderr; exit codes are 0 success, 1 the tool reported an error, 2 a usage error.
That contract is what lets a sandbox run the query and keep the bytes out of an
agent's context.

**`truncated`, `offset`, `matched_lines_total`** on `find_pattern`. Truncation is
detected by asking the scan for `limit + 1`: holding one more than requested
proves more exist. Exact, not heuristic, and the early exit is preserved — the
extra cost is the scan up to one further matching symbol.

`matched_lines_total` supplies the count `match_count`'s name implies. Both
numbers are now present and they differ, so nothing has to be guessed. When
`truncated` is true it is a floor over what was returned; no code path ever
scans the whole index.

## Additive only

This is the governing constraint of the branch, and it was verified rather than
asserted: the tool registry was rebuilt from the base commit and diffed both
ways.

- **43 tools before, 43 after** — none removed, added or reshaped. The only
  schema delta anywhere is `find_pattern` gaining an optional `offset`.
- Responses compared side by side on a real 51 568-symbol index across four
  query shapes: **every pre-existing key byte-identical**, exactly three added.
- `match_count` keeps its name and meaning. An earlier draft renamed it; that was
  dropped.
- `find_pattern_in_symbols` has exactly one caller in `src/` (both mode branches,
  both updated). `web.py` and `workspace.py` do not touch it.

## Testing

40 new tests. Full suite: **472 passed**, plus the 10 failures already red on
`develop` on Windows (`test_hooks`, `test_index_dart`,
`test_vector_cache::test_rebuild_replaces…`, 7× `test_read_only_uri…`).

Verified against two real indexes, read-only, not fixtures:

- The original overflow query returns 151 303 bytes in 1.3 s through the CLI,
  never touching an agent's context, and reports `truncated: false` with 245
  symbols over 312 matched lines — the two counts differing on real data.
- The truncation boundary probed at 244 / 245 / 246 against 51 568 symbols:
  exact, no off-by-one.
- Paging tiles a single-shot result exactly — no overlap, no gap — and
  `truncated` stays exact at `offset > 0`. Cost stays bounded: a page at
  `--offset 8000` costs 1.38 s against 1.22 s at offset 0.

## Known limits, stated rather than discovered

**The default page did not get smaller.** `find_pattern --pattern 'this->'` at
`limit=50` still returns 62 KB. Overflow is solved by the CLI/sandbox route and
by lowering `limit` — an MCP caller that ignores `truncated` is no better off
than before. A compact `format: "locations"` would address that and was
deliberately left out, since the chosen consumer is a sandbox.

**The MCP surface is now also a CLI contract.** Renaming a tool or an argument on
the MCP side renames it here. That is the price of the CLI tracking the server
with no per-tool code, and `--help` says so.

**`restart_server` is refused from the CLI** (exit 2): it `os._exit(0)`s the
process from the event loop, which a one-shot invocation cannot survive.

Deliberately out of scope: `total_matches` and `count_only` (both trade a
correctness trap for a performance one), a compact output format, and a
read-only SQL escape hatch.